### PR TITLE
fix: remove redundant microsecond suffix in parquet filename

### DIFF
--- a/src/utils/parquet_writer.py
+++ b/src/utils/parquet_writer.py
@@ -127,8 +127,7 @@ class ParquetWriter:
         # Generate filename with timestamp (including microseconds for uniqueness)
         now = datetime.now(timezone.utc)
         timestamp = now.strftime('%Y%m%d_%H%M%S_%f')
-        microseconds = f"{now.microsecond:06d}"
-        filename = f"data_{timestamp}_{microseconds}.parquet"
+        filename = f"data_{timestamp}.parquet"
         file_path = output_path / filename
 
         # Write to Parquet


### PR DESCRIPTION
## Summary
- `strftime('%f')`가 이미 microsecond 6자리를 포함하므로 `now.microsecond`를 suffix로 추가 붙이는 코드 제거
- 중복 파일명 `data_20260309_101530_123456_123456.parquet` → `data_20260309_101530_123456.parquet`로 단순화

Closes #29

## Test plan
- [x] `pytest tests/test_parquet_writer.py -v` — 13 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)