### PR TITLE
fix: populate service_id in ReviewMasterIndex via app_metadata lookup

### DIFF
--- a/src/loaders/batch_loader.py
+++ b/src/loaders/batch_loader.py
@@ -183,7 +183,8 @@ class BatchLoader:
         """app_metadata에서 현재 유효한 service_id 조회."""
         row = (
             session.query(AppMetadata.service_id)
-            .filter_by(app_id=app_id, is_active=True)
+            .filter(AppMetadata.app_id == app_id, AppMetadata.is_active == True)
+            .order_by(AppMetadata.valid_from.desc())
             .first()
         )
         if row is None:

--- a/tests/test_batch_loader.py
+++ b/tests/test_batch_loader.py
@@ -327,9 +327,21 @@ def test_service_id_none_when_no_app_metadata(test_db_session):
     import pyarrow as pa
 
     now = datetime.now(timezone.utc)
+    app_id = uuid7()
+
+    # App row만 생성 (AppMetadata 없음) — FK 제약 충족하면서 no-metadata 경로 테스트
+    app = App(
+        app_id=app_id,
+        platform_app_id='no_meta_app',
+        platform_type=PlatformType.APPSTORE,
+        name='No Meta App',
+    )
+    test_db_session.add(app)
+    test_db_session.commit()
+
     review_schema = AppReviewSchema(
         review_id=str(uuid7()),
-        app_id=str(uuid7()),  # 매칭되는 app_metadata 없음
+        app_id=str(app_id),  # App은 있지만 AppMetadata 없음
         platform_type='APPSTORE',
         platform_review_id='no_meta_review_001',
         reviewer_name='User1',
@@ -367,6 +379,7 @@ def test_service_id_none_when_no_app_metadata(test_db_session):
     ).first()
     assert review is not None
     assert review.service_id is None, "service_id should be None when app_metadata is missing"
+    loader.logger.warning.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary

- `BatchLoader._load_single_batch()`에서 `ReviewMasterIndex` 생성 시 `service_id`가 누락되던 문제 수정
- `app_metadata` 테이블에서 `app_id` → `service_id` 조회 후 채움
- 배치 내 동일 `app_id` 반복 조회 방지를 위해 dict 캐시 사용

## Test plan

- [x] `test_service_id_populated_from_app_metadata`: `AppService` → `App` → `AppMetadata` FK 생성 후 적재 시 `service_id` 정상 채워지는지 확인
- [x] `test_service_id_none_when_no_app_metadata`: 매칭되는 `app_metadata` 없을 때 `service_id = None` + warning 로그 확인

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Data Quality**
  * Review records now include associated service ID information when available.

* **Performance**
  * Service ID resolution is cached per app to reduce redundant lookups.

* **Tests**
  * Added tests verifying service ID is populated from app metadata and behavior when metadata is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->