### PR TITLE
fix: GoldABSAAnalyzer 부정어/부사 가중치를 키워드 단위로 적용 (closes #50)

### DIFF
--- a/src/gold/absa_analyzer.py
+++ b/src/gold/absa_analyzer.py
@@ -71,6 +71,9 @@ _ADV_WEIGHTS: Dict[str, float] = {
 # 부정어
 _NEGATION_WORDS = {"안", "못", "없", "아니", "않"}
 
+# 키워드별 컨텍스트 윈도우 크기 (±N 토큰)
+_CONTEXT_WINDOW: int = 3
+
 # ----------------------------------------------------------------
 # 카테고리 키워드 사전  {CategoryType: [키워드...]}
 # ----------------------------------------------------------------
@@ -209,15 +212,16 @@ class GoldABSAAnalyzer:
         self, session, review_id: UUID, text: str
     ) -> List[ReviewAspect]:
         """텍스트에서 aspect 목록을 추출하여 ReviewAspect 리스트 반환."""
-        keywords = self._extract_keywords(text)
-        if not keywords:
+        keywords_with_spans = self._extract_keywords_with_spans(text)
+        if not keywords_with_spans:
             return []
 
-        has_negation = self._has_negation(text)
-        adv_weight = self._get_adv_weight(text)
-
         aspects: List[ReviewAspect] = []
-        for keyword in keywords:
+        for keyword, kw_start, kw_end in keywords_with_spans:
+            context = self._local_context(text, kw_start, kw_end)
+            has_negation = self._has_negation(context)
+            adv_weight = self._get_adv_weight(context)
+
             s_base = _SENTIMENT_DICT.get(keyword, 0.5)
             s_final = s_base * adv_weight
             if has_negation:
@@ -237,6 +241,10 @@ class GoldABSAAnalyzer:
 
     def _extract_keywords(self, text: str) -> List[str]:
         """KoNLPy Okt로 명사 추출. unavailable 시 규칙 기반 fallback."""
+        return [kw for kw, _, _ in self._extract_keywords_with_spans(text)]
+
+    def _extract_keywords_with_spans(self, text: str) -> List[Tuple[str, int, int]]:
+        """키워드와 문자 단위 span (start, end)을 함께 반환."""
         if self._okt:
             try:
                 nouns = self._okt.nouns(text)
@@ -244,8 +252,13 @@ class GoldABSAAnalyzer:
                 in_dict = [n for n in nouns if n in _SENTIMENT_DICT or n in _KEYWORD_TO_CATEGORY]
                 in_dict_set = set(in_dict)
                 others = [n for n in nouns if len(n) >= 2 and n not in in_dict_set]
-                filtered = list(dict.fromkeys(in_dict + others))
-                return filtered[:20]  # 최대 20개
+                filtered = list(dict.fromkeys(in_dict + others))[:20]
+                result: List[Tuple[str, int, int]] = []
+                for noun in filtered:
+                    idx = text.find(noun)
+                    if idx != -1:
+                        result.append((noun, idx, idx + len(noun)))
+                return result
             except Exception as e:
                 self.logger.warning(f"Okt.nouns failed: {e} — fallback to dict match")
 
@@ -256,7 +269,7 @@ class GoldABSAAnalyzer:
             key=len,
             reverse=True,
         )
-        found: List[str] = []
+        found: List[Tuple[str, int, int]] = []
         matched_spans: List[Tuple[int, int]] = []
         for kw in candidates:
             start = 0
@@ -266,13 +279,29 @@ class GoldABSAAnalyzer:
                     break
                 end = idx + len(kw)
                 if not any(s < end and idx < e for s, e in matched_spans):
-                    found.append(kw)
+                    found.append((kw, idx, end))
                     matched_spans.append((idx, end))
                     break
                 start = idx + 1
             if len(found) >= 20:
                 break
         return found
+
+    def _local_context(self, text: str, kw_start: int, kw_end: int) -> str:
+        """키워드 위치 주변 ±_CONTEXT_WINDOW 토큰을 추출하여 반환."""
+        tokens = text.split()
+        pos = 0
+        kw_token_idx = -1
+        for i, token in enumerate(tokens):
+            if pos <= kw_start < pos + len(token):
+                kw_token_idx = i
+                break
+            pos += len(token) + 1  # +1 for whitespace
+        if kw_token_idx == -1:
+            return text  # 위치 탐지 실패 시 전체 텍스트 fallback
+        w_start = max(0, kw_token_idx - _CONTEXT_WINDOW)
+        w_end = min(len(tokens), kw_token_idx + _CONTEXT_WINDOW + 1)
+        return " ".join(tokens[w_start:w_end])
 
     def _has_negation(self, text: str) -> bool:
         """텍스트에 부정어 포함 여부."""

--- a/src/gold/absa_analyzer.py
+++ b/src/gold/absa_analyzer.py
@@ -24,7 +24,6 @@ Usage (via orchestrator):
 from __future__ import annotations
 
 import math
-import re
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -291,19 +290,21 @@ class GoldABSAAnalyzer:
     def _local_context(self, text: str, kw_start: int, kw_end: int) -> str:
         """키워드 위치 주변 ±_CONTEXT_WINDOW 토큰을 추출하여 반환.
 
-        re.finditer로 실제 문자 오프셋을 추적하므로 연속 공백·탭·줄바꿈에도 안전.
+        입력 text는 cleanse 파이프라인에서 공백이 정규화된 상태를 가정한다.
         """
-        token_spans = [(m.group(), m.start(), m.end()) for m in re.finditer(r"\S+", text)]
+        tokens = text.split()
+        pos = 0
         kw_token_idx = -1
-        for i, (_, t_start, t_end) in enumerate(token_spans):
-            if t_start <= kw_start < t_end:
+        for i, token in enumerate(tokens):
+            if pos <= kw_start < pos + len(token):
                 kw_token_idx = i
                 break
+            pos += len(token) + 1  # +1 for single space
         if kw_token_idx == -1:
             return text  # 위치 탐지 실패 시 전체 텍스트 fallback
         w_start = max(0, kw_token_idx - _CONTEXT_WINDOW)
-        w_end = min(len(token_spans), kw_token_idx + _CONTEXT_WINDOW + 1)
-        return " ".join(t for t, _, _ in token_spans[w_start:w_end])
+        w_end = min(len(tokens), kw_token_idx + _CONTEXT_WINDOW + 1)
+        return " ".join(tokens[w_start:w_end])
 
     def _has_negation(self, text: str) -> bool:
         """텍스트에 부정어 포함 여부."""

--- a/src/gold/absa_analyzer.py
+++ b/src/gold/absa_analyzer.py
@@ -24,6 +24,7 @@ Usage (via orchestrator):
 from __future__ import annotations
 
 import math
+import re
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID
 
@@ -288,20 +289,21 @@ class GoldABSAAnalyzer:
         return found
 
     def _local_context(self, text: str, kw_start: int, kw_end: int) -> str:
-        """키워드 위치 주변 ±_CONTEXT_WINDOW 토큰을 추출하여 반환."""
-        tokens = text.split()
-        pos = 0
+        """키워드 위치 주변 ±_CONTEXT_WINDOW 토큰을 추출하여 반환.
+
+        re.finditer로 실제 문자 오프셋을 추적하므로 연속 공백·탭·줄바꿈에도 안전.
+        """
+        token_spans = [(m.group(), m.start(), m.end()) for m in re.finditer(r"\S+", text)]
         kw_token_idx = -1
-        for i, token in enumerate(tokens):
-            if pos <= kw_start < pos + len(token):
+        for i, (_, t_start, t_end) in enumerate(token_spans):
+            if t_start <= kw_start < t_end:
                 kw_token_idx = i
                 break
-            pos += len(token) + 1  # +1 for whitespace
         if kw_token_idx == -1:
             return text  # 위치 탐지 실패 시 전체 텍스트 fallback
         w_start = max(0, kw_token_idx - _CONTEXT_WINDOW)
-        w_end = min(len(tokens), kw_token_idx + _CONTEXT_WINDOW + 1)
-        return " ".join(tokens[w_start:w_end])
+        w_end = min(len(token_spans), kw_token_idx + _CONTEXT_WINDOW + 1)
+        return " ".join(t for t, _, _ in token_spans[w_start:w_end])
 
     def _has_negation(self, text: str) -> bool:
         """텍스트에 부정어 포함 여부."""

--- a/src/gold/absa_analyzer.py
+++ b/src/gold/absa_analyzer.py
@@ -218,7 +218,7 @@ class GoldABSAAnalyzer:
 
         aspects: List[ReviewAspect] = []
         for keyword, kw_start, kw_end in keywords_with_spans:
-            context = self._local_context(text, kw_start, kw_end)
+            context = self._local_context(text, kw_start)
             has_negation = self._has_negation(context)
             adv_weight = self._get_adv_weight(context)
 
@@ -287,10 +287,12 @@ class GoldABSAAnalyzer:
                 break
         return found
 
-    def _local_context(self, text: str, kw_start: int, kw_end: int) -> str:
+    def _local_context(self, text: str, kw_start: int) -> str:
         """키워드 위치 주변 ±_CONTEXT_WINDOW 토큰을 추출하여 반환.
 
         입력 text는 cleanse 파이프라인에서 공백이 정규화된 상태를 가정한다.
+        키워드가 텍스트에 여러 번 출현할 경우 첫 번째 위치 기준으로 윈도우를 구성한다.
+        (fallback 경로도 동일 동작 — 키워드당 하나의 span만 기록)
         """
         tokens = text.split()
         pos = 0

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -41,6 +41,13 @@ def remove_special_chars(text: str) -> str:
     return re.sub(r'[^\w\s!?.,\[\]]', '', text)
 
 
+def normalize_whitespace(text: str) -> str:
+    """연속 공백·탭·줄바꿈을 단일 공백으로 정규화한다."""
+    if not text:
+        return text
+    return re.sub(r'\s+', ' ', text)
+
+
 _ACCOUNT_PATTERN = re.compile(
     r'(?<!\d)\d{10,14}(?!\d)'
     r'|\b\d{3,6}-\d{2,6}-\d{3,6}\b'
@@ -116,6 +123,7 @@ class ReviewCleaner:
         text = remove_special_chars(text)
         text = self._synonym_processor.replace_keywords(text)
         text = self._profanity_processor.replace_keywords(text)
+        text = normalize_whitespace(text)
         return text.strip()
 
 

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -71,7 +71,7 @@ def mask_pii(text: str) -> str:
 
 
 # =========================================================
-# ReviewCleaner: 7-step 정제 파이프라인 클래스
+# ReviewCleaner: 8-step 정제 파이프라인 클래스
 # =========================================================
 
 import json
@@ -82,7 +82,7 @@ class ReviewCleaner:
     """텍스트 정제 파이프라인 클래스.
 
     정제 순서: NFKC → 이모지 제거 → 반복문자 축약 → PII 마스킹
-            특수문자 제거 → 오타 교정 → 비속어 마스킹
+            특수문자 제거 → 오타 교정 → 비속어 마스킹 → 공백 정규화
     """
 
     def __init__(self, synonyms_path: str, profanity_path: str):

--- a/tests/test_cleanse.py
+++ b/tests/test_cleanse.py
@@ -1,6 +1,7 @@
 import pytest
 from src.processing.cleanse import (
     normalize_unicode,
+    normalize_whitespace,
     remove_emojis,
     reduce_repeated_chars,
     remove_special_chars,
@@ -121,6 +122,27 @@ def test_mask_pii_preserves_name():
     result = mask_pii('홍길동씨가 계좌 1234567890으로 이체')
     assert '홍길동' in result
     assert '[ACC]' in result
+
+
+# ========================================
+# normalize_whitespace
+# ========================================
+
+def test_normalize_whitespace_multiple_spaces():
+    assert normalize_whitespace('편리  하고  좋아요') == '편리 하고 좋아요'
+
+def test_normalize_whitespace_tabs_and_newlines():
+    assert normalize_whitespace('편리\t빠르고\n좋아요') == '편리 빠르고 좋아요'
+
+def test_normalize_whitespace_mixed():
+    assert normalize_whitespace('좋은  \t앱\n\n입니다') == '좋은 앱 입니다'
+
+def test_normalize_whitespace_single_space_unchanged():
+    text = '편리하고 빠른 앱'
+    assert normalize_whitespace(text) == text
+
+def test_normalize_whitespace_empty():
+    assert normalize_whitespace('') == ''
 
 
 # ========================================

--- a/tests/test_gold_absa_analyzer.py
+++ b/tests/test_gold_absa_analyzer.py
@@ -124,6 +124,32 @@ class TestSentimentCalculation:
         for a in aspects:
             assert 0.0 <= a.sentiment_score <= 1.0
 
+    def test_negation_applies_only_to_nearby_keyword(self):
+        """혼합 감성: '편리한 앱인데 그냥 쓰기 좋고 오류는 안 나요'
+        편리(token 0): window[0:4] = "편리한 앱인데 그냥 쓰기" → 부정어/부사 없음 → 0.85 유지
+        오류(token 5): window[2:9] = "그냥 쓰기 좋고 오류는 안 나요" → "안" 포함 → 반전 0.90
+        """
+        text = "편리한 앱인데 그냥 쓰기 좋고 오류는 안 나요"
+        aspects = self.analyzer._analyze(MagicMock(), uuid7(), text)
+        kw_aspects = {a.keyword: a for a in aspects}
+        assert "편리" in kw_aspects
+        assert "오류" in kw_aspects
+        assert kw_aspects["편리"].sentiment_score == pytest.approx(0.85, abs=1e-4)
+        assert kw_aspects["오류"].sentiment_score == pytest.approx(0.90, abs=1e-4)
+
+    def test_adverb_applies_only_to_nearby_keyword(self):
+        """혼합 강도: '매우 편리한 기능들 좋고 그런데 오류가 있어요'
+        편리(token 1): window[0:5] = "매우 편리한 기능들 좋고 그런데" → "매우"(1.3) → 1.0
+        오류(token 5): window[2:7] = "기능들 좋고 그런데 오류가 있어요" → "매우" 없음 → 0.10 유지
+        """
+        text = "매우 편리한 기능들 좋고 그런데 오류가 있어요"
+        aspects = self.analyzer._analyze(MagicMock(), uuid7(), text)
+        kw_aspects = {a.keyword: a for a in aspects}
+        assert "편리" in kw_aspects
+        assert "오류" in kw_aspects
+        assert kw_aspects["편리"].sentiment_score == pytest.approx(1.0, abs=1e-4)
+        assert kw_aspects["오류"].sentiment_score == pytest.approx(0.10, abs=1e-4)
+
 
 # ─────────────────────────────────────────────
 # C. Keyword extraction (dict-match fallback)


### PR DESCRIPTION
## Summary

- `_analyze()`에서 부정어·부사를 **전체 텍스트 기준으로 일괄 적용**하던 버그 수정
- 각 키워드 출현 위치 주변 **±3 토큰 컨텍스트 윈도우**에서만 탐지하도록 변경
- 혼합 감성 리뷰(`"편리하지만 오류는 안 나요"`)에서 무관한 키워드가 잘못 반전되는 오류 해결

## Changes

| 파일 | 변경 |
|------|------|
| `src/gold/absa_analyzer.py` | `_extract_keywords_with_spans()`, `_local_context()` 추가; `_analyze()` 수정 |
| `tests/test_gold_absa_analyzer.py` | 컨텍스트 윈도우 검증 테스트 2개 추가 |

## Test Plan

- [x] `tests/test_gold_absa_analyzer.py` — 42개 전부 통과 (신규 2개 포함)
- [x] Gold 모듈 전체 (`absa`, `orchestrator`, `aggregator`, `action_analyzer`) — 87/87 통과
- [x] 기존 `_extract_keywords()` 시그니처 유지 (하위 호환)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sentiment modifiers (negation, intensity) now apply only within each keyword’s local context, preventing cross-keyword interference.
  * Improved fallback handling when advanced tokenization isn't available to preserve localized sentiment scope.

* **Chores**
  * Normalized intra-text whitespace during review cleaning for more consistent cleaned output.

* **Tests**
  * Added unit tests for scope-limited negation/adverb intensity and for whitespace normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->