### PR TITLE
fix: srv_daily_review_list 파티션 자동 생성 & gold_aggregate 드레인 모드 (#56, #57)

### DIFF
--- a/dags/financial_review_pipeline.py
+++ b/dags/financial_review_pipeline.py
@@ -81,7 +81,9 @@ gold_analyze = BashOperator(
     execution_timeout=timedelta(hours=3),
 )
 
-# Step 5: Gold 집계
+# Step 5: Gold 집계 (드레인 모드)
+# ANALYZED 레코드의 모든 distinct 날짜를 집계 — gold_analyze가 날짜 무관하게 전체
+# 드레인하므로, 재시도로 이전 날짜 리뷰가 ANALYZED 되더라도 집계 누락 방지.
 # UPSERT: fact_service_review_daily, fact_service_aspect_daily,
 #          fact_category_radar_scores, srv_daily_review_list
 gold_aggregate = BashOperator(
@@ -89,7 +91,7 @@ gold_aggregate = BashOperator(
     bash_command=(
         f"cd {PROJECT_ROOT} && PYTHONPATH=. {PYTHON_BIN} -c "
         '"from src.pipeline.steps import run_aggregate; import sys; '
-        "r = run_aggregate(target_date='{{ ds }}'); "
+        "r = run_aggregate(); "
         "print(r.as_dict()); "
         "sys.exit(0 if r.status == 'success' else 1)\""
     ),

--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -115,6 +115,11 @@ class GoldAggregator:
             self.logger.info(
                 f"Gold Aggregator run_all 완료: updated={updated_dates}, failed={failed_dates}"
             )
+            if failed_dates:
+                raise RuntimeError(
+                    f"Gold Aggregator run_all: 일부 날짜 집계 실패 {failed_dates} "
+                    f"(성공: {updated_dates})"
+                )
             return {
                 "dates": updated_dates,
                 "failed_dates": failed_dates,
@@ -154,7 +159,7 @@ class GoldAggregator:
         next_date = target_date + timedelta(days=1)
         ddl = text(
             f"CREATE TABLE IF NOT EXISTS public.{partition_name} "
-            f"PARTITION OF srv_daily_review_list "
+            f"PARTITION OF public.srv_daily_review_list "
             f"FOR VALUES FROM ('{target_date.isoformat()}') TO ('{next_date.isoformat()}')"
         )
         session.execute(ddl)

--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -84,28 +84,40 @@ class GoldAggregator:
         gold_analyze가 날짜 무관하게 전체 드레인하기 때문에, 재시도로 이전 날짜
         리뷰가 ANALYZED 되더라도 해당 날짜 집계가 누락되지 않도록 보장합니다.
 
+        날짜별로 독립 커밋하여 중간 실패 시에도 성공한 날짜의 진행 상황을 보존합니다.
+
         Returns:
-            {"dates": list[str], "tables_updated": list[str]}
+            {"dates": list[str], "failed_dates": list[str], "tables_updated": list[str]}
         """
         session = self.db_connector.get_session()
+        updated_dates: List[str] = []
+        failed_dates: List[str] = []
         try:
             dates = self._fetch_analyzed_dates(session)
             if not dates:
                 self.logger.info("Gold Aggregator run_all: 집계 대상 날짜 없음")
-                return {"dates": [], "tables_updated": []}
+                return {"dates": [], "failed_dates": [], "tables_updated": []}
 
             self.logger.info(f"Gold Aggregator run_all: {len(dates)}개 날짜 집계 시작")
             for d in dates:
-                self._upsert_fact_service_review_daily(session, d)
-                self._upsert_fact_service_aspect_daily(session, d)
-                self._upsert_fact_category_radar_scores(session, d)
-                self._upsert_srv_daily_review_list(session, d)
+                try:
+                    self._upsert_fact_service_review_daily(session, d)
+                    self._upsert_fact_service_aspect_daily(session, d)
+                    self._upsert_fact_category_radar_scores(session, d)
+                    self._upsert_srv_daily_review_list(session, d)
+                    session.commit()
+                    updated_dates.append(str(d))
+                except Exception:
+                    session.rollback()
+                    self.logger.exception(f"Gold Aggregator run_all 날짜 집계 실패, 스킵: date={d}")
+                    failed_dates.append(str(d))
 
-            session.commit()
-            updated_dates = [str(d) for d in dates]
-            self.logger.info(f"Gold Aggregator run_all 완료: dates={updated_dates}")
+            self.logger.info(
+                f"Gold Aggregator run_all 완료: updated={updated_dates}, failed={failed_dates}"
+            )
             return {
                 "dates": updated_dates,
+                "failed_dates": failed_dates,
                 "tables_updated": [
                     "fact_service_review_daily",
                     "fact_service_aspect_daily",
@@ -113,10 +125,6 @@ class GoldAggregator:
                     "srv_daily_review_list",
                 ],
             }
-        except Exception:
-            session.rollback()
-            self.logger.exception("Gold Aggregator run_all 실패")
-            raise
         finally:
             session.close()
 
@@ -136,15 +144,20 @@ class GoldAggregator:
         return [row.d for row in session.execute(sql)]
 
     def _ensure_partition(self, session, target_date: date) -> None:
-        """srv_daily_review_list 파티션이 없으면 생성."""
+        """srv_daily_review_list 파티션이 없으면 생성.
+
+        PostgreSQL의 FOR VALUES FROM ... TO ... 절은 bind parameter를 허용하지 않으므로
+        날짜를 ISO 문자열 리터럴로 직접 삽입. partition_name은 date.strftime으로
+        생성되어 숫자·언더스코어만 포함하므로 안전함.
+        """
         partition_name = f"srv_daily_review_list_{target_date.strftime('%Y_%m_%d')}"
         next_date = target_date + timedelta(days=1)
         ddl = text(
-            f"CREATE TABLE IF NOT EXISTS {partition_name} "
+            f"CREATE TABLE IF NOT EXISTS public.{partition_name} "
             f"PARTITION OF srv_daily_review_list "
-            f"FOR VALUES FROM (:start) TO (:end)"
+            f"FOR VALUES FROM ('{target_date.isoformat()}') TO ('{next_date.isoformat()}')"
         )
-        session.execute(ddl, {"start": target_date, "end": next_date})
+        session.execute(ddl)
         self.logger.debug(f"파티션 확인/생성: {partition_name}")
 
     def _upsert_fact_service_review_daily(self, session, target_date: date) -> None:

--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -15,8 +15,8 @@ Usage:
 
 from __future__ import annotations
 
-from datetime import date
-from typing import Optional
+from datetime import date, timedelta
+from typing import List, Optional
 
 from sqlalchemy import text
 
@@ -78,9 +78,74 @@ class GoldAggregator:
         finally:
             session.close()
 
+    def run_all(self) -> dict:
+        """ANALYZED 레코드의 모든 distinct 날짜를 집계 (드레인 모드).
+
+        gold_analyze가 날짜 무관하게 전체 드레인하기 때문에, 재시도로 이전 날짜
+        리뷰가 ANALYZED 되더라도 해당 날짜 집계가 누락되지 않도록 보장합니다.
+
+        Returns:
+            {"dates": list[str], "tables_updated": list[str]}
+        """
+        session = self.db_connector.get_session()
+        try:
+            dates = self._fetch_analyzed_dates(session)
+            if not dates:
+                self.logger.info("Gold Aggregator run_all: 집계 대상 날짜 없음")
+                return {"dates": [], "tables_updated": []}
+
+            self.logger.info(f"Gold Aggregator run_all: {len(dates)}개 날짜 집계 시작")
+            for d in dates:
+                self._upsert_fact_service_review_daily(session, d)
+                self._upsert_fact_service_aspect_daily(session, d)
+                self._upsert_fact_category_radar_scores(session, d)
+                self._upsert_srv_daily_review_list(session, d)
+
+            session.commit()
+            updated_dates = [str(d) for d in dates]
+            self.logger.info(f"Gold Aggregator run_all 완료: dates={updated_dates}")
+            return {
+                "dates": updated_dates,
+                "tables_updated": [
+                    "fact_service_review_daily",
+                    "fact_service_aspect_daily",
+                    "fact_category_radar_scores",
+                    "srv_daily_review_list",
+                ],
+            }
+        except Exception:
+            session.rollback()
+            self.logger.exception("Gold Aggregator run_all 실패")
+            raise
+        finally:
+            session.close()
+
     # ------------------------------------------------------------------
     # Per-table UPSERT helpers
     # ------------------------------------------------------------------
+
+    def _fetch_analyzed_dates(self, session) -> List[date]:
+        """ANALYZED 레코드가 존재하는 모든 distinct 날짜 조회."""
+        sql = text("""
+            SELECT DISTINCT DATE_TRUNC('day', review_created_at)::date AS d
+            FROM review_master_index
+            WHERE processing_status = 'ANALYZED'
+              AND review_created_at IS NOT NULL
+            ORDER BY d
+        """)
+        return [row.d for row in session.execute(sql)]
+
+    def _ensure_partition(self, session, target_date: date) -> None:
+        """srv_daily_review_list 파티션이 없으면 생성."""
+        partition_name = f"srv_daily_review_list_{target_date.strftime('%Y_%m_%d')}"
+        next_date = target_date + timedelta(days=1)
+        ddl = text(
+            f"CREATE TABLE IF NOT EXISTS {partition_name} "
+            f"PARTITION OF srv_daily_review_list "
+            f"FOR VALUES FROM (:start) TO (:end)"
+        )
+        session.execute(ddl, {"start": target_date, "end": next_date})
+        self.logger.debug(f"파티션 확인/생성: {partition_name}")
 
     def _upsert_fact_service_review_daily(self, session, target_date: date) -> None:
         """fact_service_review_daily UPSERT."""
@@ -182,6 +247,7 @@ class GoldAggregator:
 
     def _upsert_srv_daily_review_list(self, session, target_date: date) -> None:
         """srv_daily_review_list UPSERT (비정규화 와이드 테이블)."""
+        self._ensure_partition(session, target_date)
         sql = text("""
             INSERT INTO srv_daily_review_list (
                 review_id, date, service_id, refined_text, review_summary,

--- a/src/pipeline/steps.py
+++ b/src/pipeline/steps.py
@@ -84,19 +84,20 @@ def run_gold(batch_size: int = 100, limit: Optional[int] = None, config_path: Op
 
 
 def run_aggregate(target_date: Optional[str] = None, config_path: Optional[str] = None) -> RunResult:
-    """Run Gold Layer aggregation step (fact tables + serving mart)."""
-    from src.gold.aggregator import GoldAggregator
-    from datetime import date as _date
+    """Run Gold Layer aggregation step (fact tables + serving mart).
 
-    parsed_date = None
+    target_date 미지정 시 드레인 모드: ANALYZED 레코드의 모든 distinct 날짜를 집계.
+    gold_analyze가 날짜 무관하게 전체 드레인하므로, 재시도로 이전 날짜 리뷰가
+    ANALYZED 되더라도 집계 누락이 발생하지 않습니다.
+    """
+    from src.gold.aggregator import GoldAggregator
+
     if target_date:
         from datetime import datetime
         parsed_date = datetime.strptime(target_date, "%Y-%m-%d").date()
+        return _handle_step("aggregate", lambda: GoldAggregator(config_path).run(target_date=parsed_date))
 
-    return _handle_step(
-        "aggregate",
-        lambda: GoldAggregator(config_path).run(target_date=parsed_date or _date.today()),
-    )
+    return _handle_step("aggregate", lambda: GoldAggregator(config_path).run_all())
 
 
 def run_load(batch_size: int = 100, config_path: Optional[str] = None) -> RunResult:

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -113,6 +113,7 @@ class TestRunAll:
         assert agg._upsert_fact_service_review_daily.call_count == 3
         assert agg._upsert_srv_daily_review_list.call_count == 3
         assert result["dates"] == ["2025-01-13", "2025-01-14", "2025-01-15"]
+        assert result["failed_dates"] == []
         assert "fact_service_review_daily" in result["tables_updated"]
 
     def test_run_all_empty_returns_early(self, mock_session):
@@ -122,11 +123,15 @@ class TestRunAll:
         result = agg.run_all()
 
         assert result["dates"] == []
+        assert result["failed_dates"] == []
         mock_session.commit.assert_not_called()
 
-    def test_run_all_commits_once(self, mock_session):
+    def test_run_all_commits_per_date(self, mock_session):
+        """날짜별 독립 커밋 — 3날짜 → commit 3회."""
         agg = _make_aggregator(mock_session)
-        agg._fetch_analyzed_dates = MagicMock(return_value=[date(2025, 1, 15)])
+        agg._fetch_analyzed_dates = MagicMock(
+            return_value=[date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15)]
+        )
         for method in (
             "_upsert_fact_service_review_daily",
             "_upsert_fact_service_aspect_daily",
@@ -137,19 +142,32 @@ class TestRunAll:
 
         agg.run_all()
 
-        mock_session.commit.assert_called_once()
+        assert mock_session.commit.call_count == 3
         mock_session.close.assert_called_once()
 
-    def test_run_all_rolls_back_on_exception(self, mock_session):
+    def test_run_all_skips_failed_date_and_continues(self, mock_session):
+        """중간 날짜 실패 시 롤백 후 다음 날짜 계속 처리."""
         agg = _make_aggregator(mock_session)
-        agg._fetch_analyzed_dates = MagicMock(return_value=[date(2025, 1, 15)])
-        agg._upsert_fact_service_review_daily = MagicMock(side_effect=RuntimeError("fail"))
+        dates = [date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15)]
+        agg._fetch_analyzed_dates = MagicMock(return_value=dates)
 
-        with pytest.raises(RuntimeError):
-            agg.run_all()
+        call_count = {"n": 0}
+        def side_effect(session, d):
+            call_count["n"] += 1
+            if d == date(2025, 1, 14):
+                raise RuntimeError("DB error on Jan 14")
+        agg._upsert_fact_service_review_daily = MagicMock(side_effect=side_effect)
+        agg._upsert_fact_service_aspect_daily = MagicMock()
+        agg._upsert_fact_category_radar_scores = MagicMock()
+        agg._upsert_srv_daily_review_list = MagicMock()
 
-        mock_session.rollback.assert_called_once()
-        mock_session.commit.assert_not_called()
+        result = agg.run_all()
+
+        assert result["dates"] == ["2025-01-13", "2025-01-15"]
+        assert result["failed_dates"] == ["2025-01-14"]
+        assert mock_session.commit.call_count == 2
+        assert mock_session.rollback.call_count == 1
+        mock_session.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -165,18 +183,28 @@ class TestEnsurePartition:
         assert "srv_daily_review_list_2025_01_15" in ddl_text
         assert "PARTITION OF srv_daily_review_list" in ddl_text
 
-    def test_ensure_partition_uses_correct_date_range(self, mock_session):
+    def test_ensure_partition_embeds_literal_date_bounds(self, mock_session):
+        """FOR VALUES FROM/TO는 bind parameter 불가 — ISO 날짜 리터럴로 직접 삽입."""
         agg = _make_aggregator(mock_session)
         agg._ensure_partition(mock_session, date(2025, 1, 15))
-        params = mock_session.execute.call_args[0][1]
-        assert params["start"] == date(2025, 1, 15)
-        assert params["end"] == date(2025, 1, 16)
+        ddl_text = str(mock_session.execute.call_args[0][0])
+        assert "2025-01-15" in ddl_text
+        assert "2025-01-16" in ddl_text
+        # 파라미터 dict 없이 단일 인자로 호출됨
+        assert len(mock_session.execute.call_args[0]) == 1
 
     def test_ensure_partition_month_boundary(self, mock_session):
         agg = _make_aggregator(mock_session)
         agg._ensure_partition(mock_session, date(2025, 1, 31))
-        params = mock_session.execute.call_args[0][1]
-        assert params["end"] == date(2025, 2, 1)
+        ddl_text = str(mock_session.execute.call_args[0][0])
+        assert "2025-01-31" in ddl_text
+        assert "2025-02-01" in ddl_text
+
+    def test_ensure_partition_includes_public_schema(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._ensure_partition(mock_session, date(2025, 1, 15))
+        ddl_text = str(mock_session.execute.call_args[0][0])
+        assert "public.srv_daily_review_list_2025_01_15" in ddl_text
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -145,15 +145,13 @@ class TestRunAll:
         assert mock_session.commit.call_count == 3
         mock_session.close.assert_called_once()
 
-    def test_run_all_skips_failed_date_and_continues(self, mock_session):
-        """중간 날짜 실패 시 롤백 후 다음 날짜 계속 처리."""
+    def test_run_all_raises_if_any_date_failed(self, mock_session):
+        """실패 날짜 존재 시 RuntimeError — DAG가 실패로 인식하도록."""
         agg = _make_aggregator(mock_session)
         dates = [date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15)]
         agg._fetch_analyzed_dates = MagicMock(return_value=dates)
 
-        call_count = {"n": 0}
         def side_effect(session, d):
-            call_count["n"] += 1
             if d == date(2025, 1, 14):
                 raise RuntimeError("DB error on Jan 14")
         agg._upsert_fact_service_review_daily = MagicMock(side_effect=side_effect)
@@ -161,10 +159,10 @@ class TestRunAll:
         agg._upsert_fact_category_radar_scores = MagicMock()
         agg._upsert_srv_daily_review_list = MagicMock()
 
-        result = agg.run_all()
+        with pytest.raises(RuntimeError, match="2025-01-14"):
+            agg.run_all()
 
-        assert result["dates"] == ["2025-01-13", "2025-01-15"]
-        assert result["failed_dates"] == ["2025-01-14"]
+        # 성공 날짜는 이미 commit, 실패 날짜는 rollback — 부분 성공 보존됨
         assert mock_session.commit.call_count == 2
         assert mock_session.rollback.call_count == 1
         mock_session.close.assert_called_once()
@@ -181,7 +179,7 @@ class TestEnsurePartition:
         mock_session.execute.assert_called_once()
         ddl_text = str(mock_session.execute.call_args[0][0])
         assert "srv_daily_review_list_2025_01_15" in ddl_text
-        assert "PARTITION OF srv_daily_review_list" in ddl_text
+        assert "PARTITION OF public.srv_daily_review_list" in ddl_text
 
     def test_ensure_partition_embeds_literal_date_bounds(self, mock_session):
         """FOR VALUES FROM/TO는 bind parameter 불가 — ISO 날짜 리터럴로 직접 삽입."""

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -95,6 +95,91 @@ class TestRun:
 
 
 # ---------------------------------------------------------------------------
+# run_all() — #57 드레인 모드
+# ---------------------------------------------------------------------------
+
+class TestRunAll:
+    def test_run_all_aggregates_all_analyzed_dates(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        dates = [date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15)]
+        agg._fetch_analyzed_dates = MagicMock(return_value=dates)
+        agg._upsert_fact_service_review_daily = MagicMock()
+        agg._upsert_fact_service_aspect_daily = MagicMock()
+        agg._upsert_fact_category_radar_scores = MagicMock()
+        agg._upsert_srv_daily_review_list = MagicMock()
+
+        result = agg.run_all()
+
+        assert agg._upsert_fact_service_review_daily.call_count == 3
+        assert agg._upsert_srv_daily_review_list.call_count == 3
+        assert result["dates"] == ["2025-01-13", "2025-01-14", "2025-01-15"]
+        assert "fact_service_review_daily" in result["tables_updated"]
+
+    def test_run_all_empty_returns_early(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._fetch_analyzed_dates = MagicMock(return_value=[])
+
+        result = agg.run_all()
+
+        assert result["dates"] == []
+        mock_session.commit.assert_not_called()
+
+    def test_run_all_commits_once(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._fetch_analyzed_dates = MagicMock(return_value=[date(2025, 1, 15)])
+        for method in (
+            "_upsert_fact_service_review_daily",
+            "_upsert_fact_service_aspect_daily",
+            "_upsert_fact_category_radar_scores",
+            "_upsert_srv_daily_review_list",
+        ):
+            setattr(agg, method, MagicMock())
+
+        agg.run_all()
+
+        mock_session.commit.assert_called_once()
+        mock_session.close.assert_called_once()
+
+    def test_run_all_rolls_back_on_exception(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._fetch_analyzed_dates = MagicMock(return_value=[date(2025, 1, 15)])
+        agg._upsert_fact_service_review_daily = MagicMock(side_effect=RuntimeError("fail"))
+
+        with pytest.raises(RuntimeError):
+            agg.run_all()
+
+        mock_session.rollback.assert_called_once()
+        mock_session.commit.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _ensure_partition() — #56 파티션 자동 생성
+# ---------------------------------------------------------------------------
+
+class TestEnsurePartition:
+    def test_ensure_partition_executes_ddl(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._ensure_partition(mock_session, date(2025, 1, 15))
+        mock_session.execute.assert_called_once()
+        ddl_text = str(mock_session.execute.call_args[0][0])
+        assert "srv_daily_review_list_2025_01_15" in ddl_text
+        assert "PARTITION OF srv_daily_review_list" in ddl_text
+
+    def test_ensure_partition_uses_correct_date_range(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._ensure_partition(mock_session, date(2025, 1, 15))
+        params = mock_session.execute.call_args[0][1]
+        assert params["start"] == date(2025, 1, 15)
+        assert params["end"] == date(2025, 1, 16)
+
+    def test_ensure_partition_month_boundary(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._ensure_partition(mock_session, date(2025, 1, 31))
+        params = mock_session.execute.call_args[0][1]
+        assert params["end"] == date(2025, 2, 1)
+
+
+# ---------------------------------------------------------------------------
 # SQL execution (smoke tests — verify session.execute is called)
 # ---------------------------------------------------------------------------
 
@@ -119,4 +204,5 @@ class TestUpsertQueries:
     def test_srv_daily_review_list_executes_sql(self, mock_session):
         agg = _make_aggregator(mock_session)
         agg._upsert_srv_daily_review_list(mock_session, date(2025, 1, 15))
-        mock_session.execute.assert_called_once()
+        # _ensure_partition(DDL) + INSERT = 2 calls
+        assert mock_session.execute.call_count == 2


### PR DESCRIPTION
## Summary

### #56 — `srv_daily_review_list` 파티션 자동 생성
- `GoldAggregator._ensure_partition()` 추가: `_upsert_srv_daily_review_list` 실행 전 해당 날짜 파티션(`srv_daily_review_list_YYYY_MM_DD`)을 `CREATE TABLE IF NOT EXISTS ... PARTITION OF`로 자동 생성
- 파티션 미존재 시 `gold_aggregate` 전체 실패하던 하드 오류 수정

### #57 — `gold_aggregate` 드레인 모드 전환 (날짜 범위 누락 방지)
- `GoldAggregator.run_all()` + `_fetch_analyzed_dates()` 추가: `ANALYZED` 레코드의 모든 distinct `DATE(review_created_at)`를 조회해 각 날짜별 Fact 테이블을 UPSERT
- `run_aggregate(target_date=None)` → `run_all()` 호출 분기 추가
- DAG `gold_aggregate`에서 `target_date='{{ ds }}'` 제거: `gold_analyze`가 날짜 무관하게 전체 드레인하므로 재시도로 이전 날짜 리뷰가 ANALYZED 되더라도 집계 누락 없음

## Root Cause

`gold_analyze`는 `processing_status = CLEANED | FAILED` 전체를 드레인하므로 이전 날짜 리뷰도 처리 가능. 반면 `gold_aggregate`가 `target_date = {{ ds }}`(오늘)만 집계하면, 재시도 성공한 이전 날짜 리뷰는 Fact 테이블에서 영구 누락됨.

## Test plan

- [x] `TestEnsurePartition` (3개): DDL 생성, 날짜 범위 파라미터, 월말 경계
- [x] `TestRunAll` (4개): 다중 날짜 집계, 빈 결과 조기 반환, 단일 커밋, 롤백
- [x] 기존 `TestRun` / `TestUpsertQueries` 전부 통과 유지
- [x] 전체 테스트 스위트: 206 passed (베이스라인 199 → +7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Financial review pipeline now supports drain mode aggregation, processing all distinct analyzed review dates instead of just the current execution date. This improves data consistency and prevents aggregation gaps during retries.

* **Tests**
  * Added comprehensive test coverage for drain mode aggregation and partition management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->