### PR TITLE
fix: MinIOClient 환경 유연성 개선 — 네이티브 AWS S3 지원

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,21 @@ DATABASE_URL=postgresql+psycopg2://user:password@host:port/dbname
 # OpenAI API Key
 OPENAI_API_KEY=your_openai_api_key_here
 
-# MinIO 설정 (http(s):// prefix 없이 host:port 형식으로 작성)
+# MinIO / S3 설정
+# - 온프레미스 MinIO: MINIO_ENDPOINT=host:9000 형식으로 작성 (http(s):// prefix 없이)
+# - AWS S3 네이티브: MINIO_ENDPOINT 를 주석 처리하거나 삭제하고 IAM 자격증명 사용
 # 프로덕션 환경에서는 MINIO_USE_SSL=true 로 설정하여 TLS를 사용할 것
 MINIO_ENDPOINT=host:9000
 MINIO_ACCESS_KEY=your_access_key
 MINIO_SECRET_KEY=your_secret_key
 MINIO_BUCKET=reai-data
 MINIO_USE_SSL=false  # 로컬 개발 전용; 프로덕션에서는 반드시 true로 변경
+
+# AWS S3 네이티브 사용 예시 (MINIO_ENDPOINT 미설정 시 적용):
+# MINIO_ENDPOINT=          # 비워두거나 삭제
+# MINIO_ACCESS_KEY=AKIA...
+# MINIO_SECRET_KEY=...
+# MINIO_BUCKET=reai-data-prod
 
 # Parquet 쓰기 활성화 (false로 설정 시 MinIO 업로드 및 ingestion_batch 등록 건너뜀)
 ENABLE_PARQUET_WRITE=true

--- a/src/utils/minio_client.py
+++ b/src/utils/minio_client.py
@@ -39,8 +39,9 @@ class MinIOClient:
         self.bucket = bucket or os.environ['MINIO_BUCKET']
 
         if bool(self.access_key) != bool(self.secret_key):
-            logger.warning(
-                "access_key와 secret_key 중 하나만 설정됨 — boto3가 PartialCredentialsError로 실패할 수 있습니다."
+            raise ValueError(
+                "access_key와 secret_key는 둘 다 설정하거나 둘 다 생략해야 합니다 "
+                "(둘 다 생략 시 IAM/기본 인증 체계 사용)."
             )
 
         client_kwargs = dict(

--- a/src/utils/minio_client.py
+++ b/src/utils/minio_client.py
@@ -28,22 +28,23 @@ class MinIOClient:
         secret_key: str = None,
         bucket: str = None,
     ):
-        raw_endpoint = endpoint or os.environ['MINIO_ENDPOINT']
-        if not raw_endpoint.startswith(('http://', 'https://')):
+        raw_endpoint = endpoint or os.environ.get('MINIO_ENDPOINT', '')
+        if raw_endpoint and not raw_endpoint.startswith(('http://', 'https://')):
             use_ssl = os.environ.get('MINIO_USE_SSL', 'false').lower() == 'true'
             scheme = 'https' if use_ssl else 'http'
             raw_endpoint = f'{scheme}://{raw_endpoint}'
-        self.endpoint = raw_endpoint
-        self.access_key = access_key or os.environ['MINIO_ACCESS_KEY']
-        self.secret_key = secret_key or os.environ['MINIO_SECRET_KEY']
+        self.endpoint = raw_endpoint or None
+        self.access_key = access_key or os.environ.get('MINIO_ACCESS_KEY')
+        self.secret_key = secret_key or os.environ.get('MINIO_SECRET_KEY')
         self.bucket = bucket or os.environ['MINIO_BUCKET']
 
-        self._client = boto3.client(
-            's3',
-            endpoint_url=self.endpoint,
+        client_kwargs = dict(
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
         )
+        if self.endpoint:
+            client_kwargs['endpoint_url'] = self.endpoint
+        self._client = boto3.client('s3', **client_kwargs)
 
     def list_objects(self, prefix: str) -> List[str]:
         """주어진 prefix의 모든 객체 키를 반환한다 (1000개 초과 페이지네이션 지원)."""

--- a/src/utils/minio_client.py
+++ b/src/utils/minio_client.py
@@ -38,6 +38,11 @@ class MinIOClient:
         self.secret_key = secret_key or os.environ.get('MINIO_SECRET_KEY')
         self.bucket = bucket or os.environ['MINIO_BUCKET']
 
+        if bool(self.access_key) != bool(self.secret_key):
+            logger.warning(
+                "access_key와 secret_key 중 하나만 설정됨 — boto3가 PartialCredentialsError로 실패할 수 있습니다."
+            )
+
         client_kwargs = dict(
             aws_access_key_id=self.access_key,
             aws_secret_access_key=self.secret_key,
@@ -45,6 +50,12 @@ class MinIOClient:
         if self.endpoint:
             client_kwargs['endpoint_url'] = self.endpoint
         self._client = boto3.client('s3', **client_kwargs)
+
+        logger.info(
+            f"Initialized MinIOClient: mode={'custom endpoint' if self.endpoint else 'native AWS S3'}, "
+            f"endpoint={self.endpoint}, bucket={self.bucket}, "
+            f"credentials={'set' if self.access_key else 'not set (using IAM/default chain)'}"
+        )
 
     def list_objects(self, prefix: str) -> List[str]:
         """주어진 prefix의 모든 객체 키를 반환한다 (1000개 초과 페이지네이션 지원)."""

--- a/tests/test_minio_client.py
+++ b/tests/test_minio_client.py
@@ -109,3 +109,16 @@ def test_init_without_endpoint_omits_endpoint_url(mock_s3_constructor):
     MinIOClient(endpoint=None, access_key='a', secret_key='b', bucket='test')
     _, kwargs = mock_s3_constructor.call_args
     assert 'endpoint_url' not in kwargs
+
+
+def test_init_partial_credentials_raises(mock_s3_constructor):
+    """access_key만 있고 secret_key가 없으면 즉시 ValueError."""
+    with pytest.raises(ValueError, match="둘 다 설정하거나 둘 다 생략"):
+        MinIOClient(endpoint=None, access_key='a', secret_key=None, bucket='test')
+
+
+def test_init_no_credentials_allowed(mock_s3_constructor):
+    """둘 다 None이면 IAM 모드로 정상 초기화된다."""
+    client = MinIOClient(endpoint=None, access_key=None, secret_key=None, bucket='test')
+    assert client.access_key is None
+    assert client.secret_key is None

--- a/tests/test_minio_client.py
+++ b/tests/test_minio_client.py
@@ -14,6 +14,13 @@ def mock_s3():
         yield mock_client
 
 
+@pytest.fixture
+def mock_s3_constructor():
+    with patch('boto3.client') as mock_boto3:
+        mock_boto3.return_value = MagicMock()
+        yield mock_boto3
+
+
 def make_client():
     return MinIOClient(
         endpoint='http://localhost:9000',
@@ -88,3 +95,17 @@ def test_put_parquet_uploads(mock_s3):
     assert kwargs['Key'] == 'silver/reviews/app_id=app1/dt=2026-03-04/refined.parquet'
     assert kwargs['Bucket'] == 'reai-data'
     assert 'Body' in kwargs
+
+
+def test_init_with_endpoint_passes_endpoint_url(mock_s3_constructor):
+    """endpoint 있을 때 endpoint_url이 boto3에 전달된다."""
+    MinIOClient(endpoint='http://localhost:9000', access_key='a', secret_key='b', bucket='test')
+    _, kwargs = mock_s3_constructor.call_args
+    assert kwargs.get('endpoint_url') == 'http://localhost:9000'
+
+
+def test_init_without_endpoint_omits_endpoint_url(mock_s3_constructor):
+    """endpoint 없을 때 endpoint_url이 boto3에 전달되지 않는다."""
+    MinIOClient(endpoint=None, access_key='a', secret_key='b', bucket='test')
+    _, kwargs = mock_s3_constructor.call_args
+    assert 'endpoint_url' not in kwargs


### PR DESCRIPTION
## Summary

- `MinIOClient.__init__`에서 `MINIO_ENDPOINT` 미설정 시 `endpoint_url`을 boto3에 전달하지 않도록 수정 → 네이티브 AWS S3 라우팅 가능
- `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`를 optional로 변경 (IAM role 등 AWS 기본 인증 체계 허용)
- `.env.example`에 클라우드 전환 시 참고할 설정 예시 주석 추가

**Closes #59**

## 환경별 동작

| 환경 | `MINIO_ENDPOINT` | 동작 |
|------|-----------------|------|
| 온프레미스 MinIO | `host:9000` | 기존과 동일 |
| AWS S3 (네이티브) | 미설정 | IAM/키 기반 S3 라우팅 |
| 로컬 개발 | `localhost:9000` | 기존과 동일 |

## Test plan

- [ ] 기존 테스트 전체 통과 확인 (199 passed, 37 errors는 DB 미연결 환경 이슈로 pre-existing)
- [ ] `MINIO_ENDPOINT` 미설정 상태에서 boto3 클라이언트가 `endpoint_url` 없이 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)