### PR TITLE
feat(gold): srv_daily_review_list TTL 파티션 삭제 자동화 (#56)

### DIFF
--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -78,17 +78,20 @@ class GoldAggregator:
             session.close()
 
         dropped = 0
-        session = self.db_connector.get_session()
         try:
-            dropped = self._drop_old_partitions(session, retention_days)
-            session.commit()
+            session = self.db_connector.get_session()
+            try:
+                dropped = self._drop_old_partitions(session, retention_days)
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
+            finally:
+                session.close()
         except Exception:
-            session.rollback()
             self.logger.exception(
                 f"TTL 파티션 삭제 실패(집계는 성공 커밋됨): target_date={target_date}"
             )
-        finally:
-            session.close()
 
         self.logger.info(
             f"Gold Aggregator 완료: date={target_date}, tables={updated}, "
@@ -103,7 +106,7 @@ class GoldAggregator:
         리뷰가 ANALYZED 되더라도 해당 날짜 집계가 누락되지 않도록 보장합니다.
 
         날짜별로 독립 커밋하여 중간 실패 시에도 성공한 날짜의 진행 상황을 보존합니다.
-        집계 루프 완료 후 TTL 파티션 삭제를 별도 트랜잭션으로 실행합니다.
+        모든 날짜 집계가 성공한 경우에만 TTL 파티션 삭제를 별도 트랜잭션으로 실행합니다.
 
         Returns:
             {"dates": list[str], "failed_dates": list[str], "tables_updated": list[str], "dropped_partitions": int}
@@ -143,15 +146,18 @@ class GoldAggregator:
             session.close()
 
         dropped = 0
-        session = self.db_connector.get_session()
         try:
-            dropped = self._drop_old_partitions(session, retention_days)
-            session.commit()
+            session = self.db_connector.get_session()
+            try:
+                dropped = self._drop_old_partitions(session, retention_days)
+                session.commit()
+            except Exception:
+                session.rollback()
+                raise
+            finally:
+                session.close()
         except Exception:
-            session.rollback()
             self.logger.exception("run_all TTL 파티션 삭제 실패(집계는 성공 커밋됨)")
-        finally:
-            session.close()
 
         return {
             "dates": updated_dates,

--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -68,14 +68,7 @@ class GoldAggregator:
             self._upsert_srv_daily_review_list(session, target_date)
             updated.append("srv_daily_review_list")
 
-            dropped = self._drop_old_partitions(session, retention_days)
-
             session.commit()
-            self.logger.info(
-                f"Gold Aggregator 완료: date={target_date}, tables={updated}, "
-                f"dropped_partitions={dropped}"
-            )
-            return {"date": str(target_date), "tables_updated": updated, "dropped_partitions": dropped}
 
         except Exception:
             session.rollback()
@@ -84,16 +77,36 @@ class GoldAggregator:
         finally:
             session.close()
 
-    def run_all(self) -> dict:
+        dropped = 0
+        session = self.db_connector.get_session()
+        try:
+            dropped = self._drop_old_partitions(session, retention_days)
+            session.commit()
+        except Exception:
+            session.rollback()
+            self.logger.exception(
+                f"TTL 파티션 삭제 실패(집계는 성공 커밋됨): target_date={target_date}"
+            )
+        finally:
+            session.close()
+
+        self.logger.info(
+            f"Gold Aggregator 완료: date={target_date}, tables={updated}, "
+            f"dropped_partitions={dropped}"
+        )
+        return {"date": str(target_date), "tables_updated": updated, "dropped_partitions": dropped}
+
+    def run_all(self, retention_days: int = 14) -> dict:
         """ANALYZED 레코드의 모든 distinct 날짜를 집계 (드레인 모드).
 
         gold_analyze가 날짜 무관하게 전체 드레인하기 때문에, 재시도로 이전 날짜
         리뷰가 ANALYZED 되더라도 해당 날짜 집계가 누락되지 않도록 보장합니다.
 
         날짜별로 독립 커밋하여 중간 실패 시에도 성공한 날짜의 진행 상황을 보존합니다.
+        집계 루프 완료 후 TTL 파티션 삭제를 별도 트랜잭션으로 실행합니다.
 
         Returns:
-            {"dates": list[str], "failed_dates": list[str], "tables_updated": list[str]}
+            {"dates": list[str], "failed_dates": list[str], "tables_updated": list[str], "dropped_partitions": int}
         """
         session = self.db_connector.get_session()
         updated_dates: List[str] = []
@@ -102,7 +115,7 @@ class GoldAggregator:
             dates = self._fetch_analyzed_dates(session)
             if not dates:
                 self.logger.info("Gold Aggregator run_all: 집계 대상 날짜 없음")
-                return {"dates": [], "failed_dates": [], "tables_updated": []}
+                return {"dates": [], "failed_dates": [], "tables_updated": [], "dropped_partitions": 0}
 
             self.logger.info(f"Gold Aggregator run_all: {len(dates)}개 날짜 집계 시작")
             for d in dates:
@@ -126,18 +139,31 @@ class GoldAggregator:
                     f"Gold Aggregator run_all: 일부 날짜 집계 실패 {failed_dates} "
                     f"(성공: {updated_dates})"
                 )
-            return {
-                "dates": updated_dates,
-                "failed_dates": failed_dates,
-                "tables_updated": [
-                    "fact_service_review_daily",
-                    "fact_service_aspect_daily",
-                    "fact_category_radar_scores",
-                    "srv_daily_review_list",
-                ],
-            }
         finally:
             session.close()
+
+        dropped = 0
+        session = self.db_connector.get_session()
+        try:
+            dropped = self._drop_old_partitions(session, retention_days)
+            session.commit()
+        except Exception:
+            session.rollback()
+            self.logger.exception("run_all TTL 파티션 삭제 실패(집계는 성공 커밋됨)")
+        finally:
+            session.close()
+
+        return {
+            "dates": updated_dates,
+            "failed_dates": failed_dates,
+            "tables_updated": [
+                "fact_service_review_daily",
+                "fact_service_aspect_daily",
+                "fact_category_radar_scores",
+                "srv_daily_review_list",
+            ],
+            "dropped_partitions": dropped,
+        }
 
     # ------------------------------------------------------------------
     # Per-table UPSERT helpers

--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -38,14 +38,15 @@ class GoldAggregator:
     # Public API
     # ------------------------------------------------------------------
 
-    def run(self, target_date: Optional[date] = None) -> dict:
+    def run(self, target_date: Optional[date] = None, retention_days: int = 14) -> dict:
         """target_date 기준 집계 실행.
 
         Args:
             target_date: 집계할 날짜. None이면 오늘 날짜 사용.
+            retention_days: 파티션 보존 기간(일). 기본 14일.
 
         Returns:
-            {"date": str, "tables_updated": list[str]}
+            {"date": str, "tables_updated": list[str], "dropped_partitions": int}
         """
         if target_date is None:
             target_date = date.today()
@@ -67,9 +68,14 @@ class GoldAggregator:
             self._upsert_srv_daily_review_list(session, target_date)
             updated.append("srv_daily_review_list")
 
+            dropped = self._drop_old_partitions(session, retention_days)
+
             session.commit()
-            self.logger.info(f"Gold Aggregator 완료: date={target_date}, tables={updated}")
-            return {"date": str(target_date), "tables_updated": updated}
+            self.logger.info(
+                f"Gold Aggregator 완료: date={target_date}, tables={updated}, "
+                f"dropped_partitions={dropped}"
+            )
+            return {"date": str(target_date), "tables_updated": updated, "dropped_partitions": dropped}
 
         except Exception:
             session.rollback()
@@ -147,6 +153,32 @@ class GoldAggregator:
             ORDER BY d
         """)
         return [row.d for row in session.execute(sql)]
+
+    def _drop_old_partitions(self, session, retention_days: int = 14) -> int:
+        """retention_days 초과 파티션 DROP.
+
+        pg_catalog.pg_inherits 에서 srv_daily_review_list 자식 파티션 목록을 조회하고,
+        파티션명에서 날짜를 파싱하여 cutoff 이전 파티션을 삭제한다.
+        """
+        cutoff = date.today() - timedelta(days=retention_days)
+        sql = text(r"""
+            SELECT c.relname
+            FROM pg_catalog.pg_inherits i
+            JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
+            JOIN pg_catalog.pg_class p ON p.oid = i.inhparentid
+            WHERE p.relname = 'srv_daily_review_list'
+              AND c.relname ~ '^srv_daily_review_list_\d{4}_\d{2}_\d{2}$'
+        """)
+        rows = session.execute(sql).fetchall()
+        dropped = 0
+        for (relname,) in rows:
+            date_part = relname[len("srv_daily_review_list_"):]
+            partition_date = date.fromisoformat(date_part.replace("_", "-"))
+            if partition_date < cutoff:
+                session.execute(text(f"DROP TABLE IF EXISTS public.{relname}"))
+                self.logger.info(f"파티션 삭제: {relname}")
+                dropped += 1
+        return dropped
 
     def _ensure_partition(self, session, target_date: date) -> None:
         """srv_daily_review_list 파티션이 없으면 생성.

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -83,8 +83,9 @@ class TestRun:
 
         agg.run(target_date=date.today())
 
-        mock_session.commit.assert_called_once()
-        mock_session.close.assert_called_once()
+        # 집계 트랜잭션 1회 + TTL 트랜잭션 1회 = 2회
+        assert mock_session.commit.call_count == 2
+        assert mock_session.close.call_count == 2
 
     def test_run_rolls_back_on_exception(self, mock_session):
         agg = _make_aggregator(mock_session)
@@ -111,6 +112,7 @@ class TestRunAll:
         agg._upsert_fact_service_aspect_daily = MagicMock()
         agg._upsert_fact_category_radar_scores = MagicMock()
         agg._upsert_srv_daily_review_list = MagicMock()
+        agg._drop_old_partitions = MagicMock(return_value=2)
 
         result = agg.run_all()
 
@@ -119,6 +121,7 @@ class TestRunAll:
         assert result["dates"] == ["2025-01-13", "2025-01-14", "2025-01-15"]
         assert result["failed_dates"] == []
         assert "fact_service_review_daily" in result["tables_updated"]
+        assert result["dropped_partitions"] == 2
 
     def test_run_all_empty_returns_early(self, mock_session):
         agg = _make_aggregator(mock_session)
@@ -128,10 +131,11 @@ class TestRunAll:
 
         assert result["dates"] == []
         assert result["failed_dates"] == []
+        assert result["dropped_partitions"] == 0
         mock_session.commit.assert_not_called()
 
     def test_run_all_commits_per_date(self, mock_session):
-        """날짜별 독립 커밋 — 3날짜 → commit 3회."""
+        """날짜별 독립 커밋 3회 + TTL 커밋 1회 = 총 4회."""
         agg = _make_aggregator(mock_session)
         agg._fetch_analyzed_dates = MagicMock(
             return_value=[date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15)]
@@ -141,13 +145,14 @@ class TestRunAll:
             "_upsert_fact_service_aspect_daily",
             "_upsert_fact_category_radar_scores",
             "_upsert_srv_daily_review_list",
+            "_drop_old_partitions",
         ):
-            setattr(agg, method, MagicMock())
+            setattr(agg, method, MagicMock(return_value=0))
 
         agg.run_all()
 
-        assert mock_session.commit.call_count == 3
-        mock_session.close.assert_called_once()
+        assert mock_session.commit.call_count == 4  # 3 per-date + 1 TTL
+        assert mock_session.close.call_count == 2   # 집계 세션 + TTL 세션
 
     def test_run_all_raises_if_any_date_failed(self, mock_session):
         """실패 날짜 존재 시 RuntimeError — DAG가 실패로 인식하도록."""

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -1,6 +1,6 @@
 """Unit tests for GoldAggregator."""
 
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import MagicMock, patch, call
 
 import pytest
@@ -40,6 +40,7 @@ class TestRun:
         agg._upsert_fact_service_aspect_daily = MagicMock()
         agg._upsert_fact_category_radar_scores = MagicMock()
         agg._upsert_srv_daily_review_list = MagicMock()
+        agg._drop_old_partitions = MagicMock(return_value=0)
 
         target = date(2025, 1, 15)
         result = agg.run(target_date=target)
@@ -55,6 +56,7 @@ class TestRun:
             "fact_category_radar_scores",
             "srv_daily_review_list",
         }
+        assert result["dropped_partitions"] == 0
 
     def test_run_defaults_to_today(self, mock_session):
         agg = _make_aggregator(mock_session)
@@ -62,6 +64,7 @@ class TestRun:
         agg._upsert_fact_service_aspect_daily = MagicMock()
         agg._upsert_fact_category_radar_scores = MagicMock()
         agg._upsert_srv_daily_review_list = MagicMock()
+        agg._drop_old_partitions = MagicMock(return_value=0)
 
         result = agg.run(target_date=None)
 
@@ -74,8 +77,9 @@ class TestRun:
             "_upsert_fact_service_aspect_daily",
             "_upsert_fact_category_radar_scores",
             "_upsert_srv_daily_review_list",
+            "_drop_old_partitions",
         ):
-            setattr(agg, method, MagicMock())
+            setattr(agg, method, MagicMock(return_value=0))
 
         agg.run(target_date=date.today())
 
@@ -232,3 +236,82 @@ class TestUpsertQueries:
         agg._upsert_srv_daily_review_list(mock_session, date(2025, 1, 15))
         # _ensure_partition(DDL) + INSERT = 2 calls
         assert mock_session.execute.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _drop_old_partitions() — #56 TTL 파티션 삭제
+# ---------------------------------------------------------------------------
+
+class TestDropOldPartitions:
+    def _make_session_with_partitions(self, partition_names):
+        """mock_session.execute(catalog_sql).fetchall() 이 partition_names 반환하도록 설정."""
+        session = MagicMock()
+        fetch_result = MagicMock()
+        fetch_result.fetchall.return_value = [(name,) for name in partition_names]
+        session.execute.return_value = fetch_result
+        return session
+
+    def test_drops_partitions_older_than_retention(self):
+        today = date.today()
+        old_date = today - timedelta(days=15)
+        old_name = f"srv_daily_review_list_{old_date.strftime('%Y_%m_%d')}"
+        session = self._make_session_with_partitions([old_name])
+        agg = _make_aggregator(MagicMock())
+
+        dropped = agg._drop_old_partitions(session, retention_days=14)
+
+        assert dropped == 1
+        drop_calls = [
+            str(c[0][0]) for c in session.execute.call_args_list[1:]
+        ]
+        assert any(old_name in call for call in drop_calls)
+
+    def test_skips_recent_partitions(self):
+        today = date.today()
+        recent_date = today - timedelta(days=5)
+        recent_name = f"srv_daily_review_list_{recent_date.strftime('%Y_%m_%d')}"
+        session = self._make_session_with_partitions([recent_name])
+        agg = _make_aggregator(MagicMock())
+
+        dropped = agg._drop_old_partitions(session, retention_days=14)
+
+        assert dropped == 0
+        # catalog 조회 1회만 호출, DROP 없음
+        assert session.execute.call_count == 1
+
+    def test_returns_dropped_count(self):
+        today = date.today()
+        names = [
+            f"srv_daily_review_list_{(today - timedelta(days=d)).strftime('%Y_%m_%d')}"
+            for d in (20, 30, 40)
+        ]
+        session = self._make_session_with_partitions(names)
+        agg = _make_aggregator(MagicMock())
+
+        dropped = agg._drop_old_partitions(session, retention_days=14)
+
+        assert dropped == 3
+
+    def test_no_partitions_returns_zero(self):
+        session = self._make_session_with_partitions([])
+        agg = _make_aggregator(MagicMock())
+
+        dropped = agg._drop_old_partitions(session, retention_days=14)
+
+        assert dropped == 0
+
+    def test_run_calls_drop_old_partitions(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        for method in (
+            "_upsert_fact_service_review_daily",
+            "_upsert_fact_service_aspect_daily",
+            "_upsert_fact_category_radar_scores",
+            "_upsert_srv_daily_review_list",
+        ):
+            setattr(agg, method, MagicMock())
+        agg._drop_old_partitions = MagicMock(return_value=2)
+
+        result = agg.run(target_date=date(2025, 1, 15), retention_days=7)
+
+        agg._drop_old_partitions.assert_called_once_with(mock_session, 7)
+        assert result["dropped_partitions"] == 2


### PR DESCRIPTION
## Summary

- `_drop_old_partitions(session, retention_days=14)` 구현 — `pg_catalog.pg_inherits` 쿼리로 `srv_daily_review_list` 자식 파티션 조회 후 `retention_days` 초과 파티션 `DROP TABLE IF EXISTS`
- `run()`에 `retention_days=14` 파라미터 추가 및 4개 UPSERT 완료 후 호출 통합
- `run()` 반환값에 `dropped_partitions` 키 추가
- `TestDropOldPartitions` 테스트 5개 추가 (삭제 대상/비대상 구분, 반환값, 빈 목록, `run()` 통합)

> `_ensure_partition()` 및 관련 테스트는 이미 구현 완료 상태였음

## Test plan

- [x] `tests/test_gold_aggregator.py` 21개 테스트 전부 통과
- [x] cutoff 이전 파티션만 DROP, 이후 파티션 유지 검증
- [x] `run(retention_days=7)` 호출 시 해당 값이 `_drop_old_partitions`에 전달됨 검증

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable data partition retention and automatic cleanup with a default 14-day retention period
  * Operation results now include a count of cleaned-up partitions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->