### PR TITLE
feat: add local development compose stack (#61)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,0 +1,19 @@
+# Local development settings for host-based execution against docker-compose.yml
+ENVIRONMENT=development
+LOG_LEVEL=INFO
+
+DATABASE_URL=postgresql+psycopg2://reai:reai@localhost:5432/reai
+
+# OpenAI-backed steps require a real key before analyze/embed runs.
+OPENAI_API_KEY=replace_me
+
+MINIO_ENDPOINT=localhost:9000
+MINIO_ACCESS_KEY=minio
+MINIO_SECRET_KEY=minio123
+MINIO_BUCKET=reai-data
+MINIO_USE_SSL=false
+
+ENABLE_PARQUET_WRITE=true
+
+# Keep integration tests isolated from the dev database.
+# TEST_DATABASE_URL=postgresql://testuser:testpass@localhost:5433/testdb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       retries: 10
 
   minio:
-    image: minio/minio:RELEASE.2026-01-18T03-12-05Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: reai-local-minio
     command: server /data --console-address ":9001"
     environment:
@@ -36,7 +36,7 @@ services:
       retries: 10
 
   minio-init:
-    image: minio/mc:RELEASE.2026-01-17T19-10-50Z
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     depends_on:
       minio:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+services:
+  postgres:
+    image: postgres:15-alpine
+    container_name: reai-local-postgres
+    environment:
+      POSTGRES_DB: reai
+      POSTGRES_USER: reai
+      POSTGRES_PASSWORD: reai
+      POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U reai -d reai"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: minio/minio:RELEASE.2026-01-18T03-12-05Z
+    container_name: reai-local-minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  minio-init:
+    image: minio/mc:RELEASE.2026-01-17T19-10-50Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 minio minio123 &&
+      mc mb --ignore-existing local/reai-data
+      "
+    restart: "no"
+
+volumes:
+  postgres-data:
+  minio-data:

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,0 +1,43 @@
+# Local Development Stack
+
+This project can run its local infrastructure with Docker Compose using PostgreSQL and MinIO only.
+
+## Start the stack
+
+```bash
+docker compose up -d
+```
+
+Services:
+
+- PostgreSQL: `localhost:5432`
+- MinIO API: `localhost:9000`
+- MinIO Console: `http://localhost:9001`
+
+The `minio-init` one-shot service creates the `reai-data` bucket automatically.
+
+## Configure the app
+
+Create a local env file from `.env.local.example` and load it before running scripts from the host environment.
+
+Key values in `.env.local.example`:
+
+- `DATABASE_URL=postgresql+psycopg2://reai:reai@localhost:5432/reai`
+- `MINIO_ENDPOINT=localhost:9000`
+- `MINIO_BUCKET=reai-data`
+
+## Stop the stack
+
+```bash
+docker compose down
+```
+
+To remove persisted local data as well:
+
+```bash
+docker compose down -v
+```
+
+## Scope note
+
+Airflow is intentionally out of scope for this compose file. Add it separately once the local infra-only workflow is stable.

--- a/docs/superpowers/plans/2026-04-18-local-dev-compose.md
+++ b/docs/superpowers/plans/2026-04-18-local-dev-compose.md
@@ -36,7 +36,7 @@ services:
   postgres:
     image: postgres:15-alpine
   minio:
-    image: minio/minio:RELEASE.2026-01-18T03-12-05Z
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -79,7 +79,7 @@ services:
     ports:
       - "5432:5432"
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     ports:
       - "9000:9000"

--- a/docs/superpowers/plans/2026-04-18-local-dev-compose.md
+++ b/docs/superpowers/plans/2026-04-18-local-dev-compose.md
@@ -1,0 +1,139 @@
+# Local Dev Compose Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a local development stack with PostgreSQL and MinIO plus a matching env template and usage docs.
+
+**Architecture:** Keep the scope intentionally small: one root `docker-compose.yml` for infrastructure services only, one `.env.local.example` for host-based local app execution, and one short guide explaining startup and endpoint mapping. Reuse the existing `docker-compose.test.yml` unchanged for test-only workflows.
+
+**Tech Stack:** Docker Compose, PostgreSQL 15, MinIO, pytest, PyYAML
+
+---
+
+### Task 1: Guard the local dev contract with tests
+
+**Files:**
+- Create: `tests/test_local_dev_setup.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_local_dev_compose_declares_postgres_and_minio():
+    compose = load_compose()
+    assert "postgres" in compose["services"]
+    assert "minio" in compose["services"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. uv run pytest tests/test_local_dev_setup.py -q`
+Expected: FAIL because `docker-compose.yml` and `.env.local.example` do not exist yet
+
+- [ ] **Step 3: Write minimal implementation**
+
+```yaml
+services:
+  postgres:
+    image: postgres:15-alpine
+  minio:
+    image: minio/minio:RELEASE.2026-01-18T03-12-05Z
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. uv run pytest tests/test_local_dev_setup.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/test_local_dev_setup.py docker-compose.yml .env.local.example docs/local-development.md
+git commit -m "test: cover local dev compose setup"
+```
+
+### Task 2: Add the local development compose stack
+
+**Files:**
+- Create: `docker-compose.yml`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_postgres_and_minio_ports_are_exposed_for_host_use():
+    compose = load_compose()
+    assert compose["services"]["postgres"]["ports"] == ["5432:5432"]
+    assert compose["services"]["minio"]["ports"] == ["9000:9000", "9001:9001"]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. uv run pytest tests/test_local_dev_setup.py -q`
+Expected: FAIL because the initial compose file does not yet declare the required ports, healthcheck, command, and volumes
+
+- [ ] **Step 3: Write minimal implementation**
+
+```yaml
+services:
+  postgres:
+    image: postgres:15-alpine
+    ports:
+      - "5432:5432"
+  minio:
+    image: minio/minio:latest
+    command: server /data --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. uv run pytest tests/test_local_dev_setup.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docker-compose.yml tests/test_local_dev_setup.py
+git commit -m "feat: add local postgres and minio compose stack"
+```
+
+### Task 3: Add a host-friendly env template and docs
+
+**Files:**
+- Create: `.env.local.example`
+- Create: `docs/local-development.md`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_local_env_template_uses_localhost_endpoints():
+    env = read_env_template(".env.local.example")
+    assert env["DATABASE_URL"] == "postgresql+psycopg2://reai:reai@localhost:5432/reai"
+    assert env["MINIO_ENDPOINT"] == "localhost:9000"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `PYTHONPATH=. uv run pytest tests/test_local_dev_setup.py -q`
+Expected: FAIL because the env template and docs are missing
+
+- [ ] **Step 3: Write minimal implementation**
+
+```dotenv
+DATABASE_URL=postgresql+psycopg2://reai:reai@localhost:5432/reai
+MINIO_ENDPOINT=localhost:9000
+MINIO_BUCKET=reai-data
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `PYTHONPATH=. uv run pytest tests/test_local_dev_setup.py -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .env.local.example docs/local-development.md tests/test_local_dev_setup.py
+git commit -m "docs: document local development stack"
+```

--- a/tests/test_local_dev_setup.py
+++ b/tests/test_local_dev_setup.py
@@ -40,6 +40,13 @@ def test_postgres_and_minio_ports_are_exposed_for_host_use():
     assert compose["services"]["minio"]["ports"] == ["9000:9000", "9001:9001"]
 
 
+def test_minio_images_use_existing_official_tags():
+    compose = load_compose()
+
+    assert compose["services"]["minio"]["image"] == "minio/minio:RELEASE.2025-09-07T16-13-09Z"
+    assert compose["services"]["minio-init"]["image"] == "minio/mc:RELEASE.2025-08-13T08-35-41Z"
+
+
 def test_local_env_template_uses_localhost_endpoints():
     env = read_env_template(".env.local.example")
 

--- a/tests/test_local_dev_setup.py
+++ b/tests/test_local_dev_setup.py
@@ -40,9 +40,10 @@ def test_postgres_and_minio_ports_are_exposed_for_host_use():
     assert compose["services"]["minio"]["ports"] == ["9000:9000", "9001:9001"]
 
 
-def test_minio_images_use_existing_official_tags():
+def test_minio_images_use_pinned_official_release_tags():
     compose = load_compose()
 
+    # This pins local development to reviewed release tags.
     assert compose["services"]["minio"]["image"] == "minio/minio:RELEASE.2025-09-07T16-13-09Z"
     assert compose["services"]["minio-init"]["image"] == "minio/mc:RELEASE.2025-08-13T08-35-41Z"
 

--- a/tests/test_local_dev_setup.py
+++ b/tests/test_local_dev_setup.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_compose():
+    compose_path = ROOT / "docker-compose.yml"
+    assert compose_path.exists(), "docker-compose.yml must exist for local development"
+    return yaml.safe_load(compose_path.read_text())
+
+
+def read_env_template(path: str) -> dict[str, str]:
+    env_path = ROOT / path
+    assert env_path.exists(), f"{path} must exist for local development"
+
+    values = {}
+    for line in env_path.read_text().splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, value = stripped.split("=", 1)
+        values[key] = value
+    return values
+
+
+def test_local_dev_compose_declares_postgres_and_minio():
+    compose = load_compose()
+
+    assert "postgres" in compose["services"]
+    assert "minio" in compose["services"]
+
+
+def test_postgres_and_minio_ports_are_exposed_for_host_use():
+    compose = load_compose()
+
+    assert compose["services"]["postgres"]["ports"] == ["5432:5432"]
+    assert compose["services"]["minio"]["ports"] == ["9000:9000", "9001:9001"]
+
+
+def test_local_env_template_uses_localhost_endpoints():
+    env = read_env_template(".env.local.example")
+
+    assert env["DATABASE_URL"] == "postgresql+psycopg2://reai:reai@localhost:5432/reai"
+    assert env["MINIO_ENDPOINT"] == "localhost:9000"
+    assert env["MINIO_BUCKET"] == "reai-data"
+
+
+def test_local_docs_explain_compose_startup():
+    docs_path = ROOT / "docs" / "local-development.md"
+    assert docs_path.exists(), "docs/local-development.md must exist"
+
+    content = docs_path.read_text()
+    assert "docker compose up -d" in content
+    assert ".env.local.example" in content
+    assert "Airflow" in content


### PR DESCRIPTION
## Summary
- add a root docker-compose.yml for local PostgreSQL and MinIO
- add a host-oriented .env.local.example for local script execution
- add local setup documentation and tests covering the local dev contract

## Validation
- PYTHONPATH=. uv run pytest tests/test_local_dev_setup.py -q
- docker compose config
