### PR TITLE
[codex] fix(gold): autocommit partition ddl (#64)

### DIFF
--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -212,12 +212,15 @@ class GoldAggregator:
                 dropped += 1
         return dropped
 
-    def _ensure_partition(self, session, target_date: date) -> None:
+    def _ensure_partition(self, target_date: date) -> None:
         """srv_daily_review_list 파티션이 없으면 생성.
 
         PostgreSQL의 FOR VALUES FROM ... TO ... 절은 bind parameter를 허용하지 않으므로
         날짜를 ISO 문자열 리터럴로 직접 삽입. partition_name은 date.strftime으로
         생성되어 숫자·언더스코어만 포함하므로 안전함.
+
+        집계 트랜잭션과 분리된 autocommit 연결에서 DDL을 즉시 커밋하여 parent table
+        락 보유 시간을 최소화한다.
         """
         partition_name = f"srv_daily_review_list_{target_date.strftime('%Y_%m_%d')}"
         next_date = target_date + timedelta(days=1)
@@ -226,7 +229,8 @@ class GoldAggregator:
             f"PARTITION OF public.srv_daily_review_list "
             f"FOR VALUES FROM ('{target_date.isoformat()}') TO ('{next_date.isoformat()}')"
         )
-        session.execute(ddl)
+        with self.db_connector.get_autocommit_connection() as conn:
+            conn.execute(ddl)
         self.logger.debug(f"파티션 확인/생성: {partition_name}")
 
     def _upsert_fact_service_review_daily(self, session, target_date: date) -> None:
@@ -329,7 +333,7 @@ class GoldAggregator:
 
     def _upsert_srv_daily_review_list(self, session, target_date: date) -> None:
         """srv_daily_review_list UPSERT (비정규화 와이드 테이블)."""
-        self._ensure_partition(session, target_date)
+        self._ensure_partition(target_date)
         sql = text("""
             INSERT INTO srv_daily_review_list (
                 review_id, date, service_id, refined_text, review_summary,

--- a/src/utils/db_connector.py
+++ b/src/utils/db_connector.py
@@ -2,6 +2,8 @@
 데이터베이스 연결 유틸리티
 """
 import os
+from contextlib import contextmanager
+
 import yaml
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
@@ -82,6 +84,12 @@ class DatabaseConnector:
     def get_session(self):
         """데이터베이스 세션을 반환합니다."""
         return self.Session()
+
+    @contextmanager
+    def get_autocommit_connection(self):
+        """DDL처럼 즉시 커밋이 필요한 작업용 autocommit 연결을 반환합니다."""
+        with self.engine.connect().execution_options(isolation_level="AUTOCOMMIT") as conn:
+            yield conn
 
     def create_tables(self, base):
         """테이블을 생성합니다."""

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -19,9 +19,22 @@ def mock_session():
     return session
 
 
-def _make_aggregator(mock_session):
+@pytest.fixture
+def mock_autocommit_connection():
+    conn = MagicMock()
+    conn.__enter__.return_value = conn
+    conn.__exit__.return_value = None
+    return conn
+
+
+def _make_aggregator(mock_session, mock_autocommit_connection=None):
     with patch("src.gold.aggregator.DatabaseConnector") as MockDB:
         MockDB.return_value.get_session.return_value = mock_session
+        if mock_autocommit_connection is None:
+            mock_autocommit_connection = MagicMock()
+            mock_autocommit_connection.__enter__.return_value = mock_autocommit_connection
+            mock_autocommit_connection.__exit__.return_value = None
+        MockDB.return_value.get_autocommit_connection.return_value = mock_autocommit_connection
         from src.gold.aggregator import GoldAggregator
         agg = GoldAggregator.__new__(GoldAggregator)
         agg.logger = MagicMock()
@@ -182,35 +195,53 @@ class TestRunAll:
 # ---------------------------------------------------------------------------
 
 class TestEnsurePartition:
-    def test_ensure_partition_executes_ddl(self, mock_session):
-        agg = _make_aggregator(mock_session)
-        agg._ensure_partition(mock_session, date(2025, 1, 15))
-        mock_session.execute.assert_called_once()
-        ddl_text = str(mock_session.execute.call_args[0][0])
+    def test_ensure_partition_executes_ddl_in_autocommit_connection(
+        self, mock_session, mock_autocommit_connection
+    ):
+        agg = _make_aggregator(mock_session, mock_autocommit_connection)
+
+        agg._ensure_partition(date(2025, 1, 15))
+
+        agg.db_connector.get_autocommit_connection.assert_called_once_with()
+        mock_session.execute.assert_not_called()
+        mock_autocommit_connection.execute.assert_called_once()
+        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
         assert "srv_daily_review_list_2025_01_15" in ddl_text
         assert "PARTITION OF public.srv_daily_review_list" in ddl_text
 
-    def test_ensure_partition_embeds_literal_date_bounds(self, mock_session):
+    def test_ensure_partition_embeds_literal_date_bounds(
+        self, mock_session, mock_autocommit_connection
+    ):
         """FOR VALUES FROM/TO는 bind parameter 불가 — ISO 날짜 리터럴로 직접 삽입."""
-        agg = _make_aggregator(mock_session)
-        agg._ensure_partition(mock_session, date(2025, 1, 15))
-        ddl_text = str(mock_session.execute.call_args[0][0])
+        agg = _make_aggregator(mock_session, mock_autocommit_connection)
+
+        agg._ensure_partition(date(2025, 1, 15))
+
+        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
         assert "2025-01-15" in ddl_text
         assert "2025-01-16" in ddl_text
         # 파라미터 dict 없이 단일 인자로 호출됨
-        assert len(mock_session.execute.call_args[0]) == 1
+        assert len(mock_autocommit_connection.execute.call_args[0]) == 1
 
-    def test_ensure_partition_month_boundary(self, mock_session):
-        agg = _make_aggregator(mock_session)
-        agg._ensure_partition(mock_session, date(2025, 1, 31))
-        ddl_text = str(mock_session.execute.call_args[0][0])
+    def test_ensure_partition_month_boundary(
+        self, mock_session, mock_autocommit_connection
+    ):
+        agg = _make_aggregator(mock_session, mock_autocommit_connection)
+
+        agg._ensure_partition(date(2025, 1, 31))
+
+        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
         assert "2025-01-31" in ddl_text
         assert "2025-02-01" in ddl_text
 
-    def test_ensure_partition_includes_public_schema(self, mock_session):
-        agg = _make_aggregator(mock_session)
-        agg._ensure_partition(mock_session, date(2025, 1, 15))
-        ddl_text = str(mock_session.execute.call_args[0][0])
+    def test_ensure_partition_includes_public_schema(
+        self, mock_session, mock_autocommit_connection
+    ):
+        agg = _make_aggregator(mock_session, mock_autocommit_connection)
+
+        agg._ensure_partition(date(2025, 1, 15))
+
+        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
         assert "public.srv_daily_review_list_2025_01_15" in ddl_text
 
 
@@ -236,11 +267,11 @@ class TestUpsertQueries:
         agg._upsert_fact_category_radar_scores(mock_session, date(2025, 1, 15))
         mock_session.execute.assert_called_once()
 
-    def test_srv_daily_review_list_executes_sql(self, mock_session):
-        agg = _make_aggregator(mock_session)
+    def test_srv_daily_review_list_executes_sql(self, mock_session, mock_autocommit_connection):
+        agg = _make_aggregator(mock_session, mock_autocommit_connection)
         agg._upsert_srv_daily_review_list(mock_session, date(2025, 1, 15))
-        # _ensure_partition(DDL) + INSERT = 2 calls
-        assert mock_session.execute.call_count == 2
+        mock_autocommit_connection.execute.assert_called_once()
+        assert mock_session.execute.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -21,10 +21,12 @@ def mock_session():
 
 @pytest.fixture
 def mock_autocommit_connection():
-    conn = MagicMock()
-    conn.__enter__.return_value = conn
-    conn.__exit__.return_value = None
-    return conn
+    manager = MagicMock()
+    connection = MagicMock()
+    manager.__enter__.return_value = connection
+    manager.__exit__.return_value = None
+    manager.connection = connection
+    return manager
 
 
 def _make_aggregator(mock_session, mock_autocommit_connection=None):
@@ -32,7 +34,8 @@ def _make_aggregator(mock_session, mock_autocommit_connection=None):
         MockDB.return_value.get_session.return_value = mock_session
         if mock_autocommit_connection is None:
             mock_autocommit_connection = MagicMock()
-            mock_autocommit_connection.__enter__.return_value = mock_autocommit_connection
+            mock_autocommit_connection.connection = MagicMock()
+            mock_autocommit_connection.__enter__.return_value = mock_autocommit_connection.connection
             mock_autocommit_connection.__exit__.return_value = None
         MockDB.return_value.get_autocommit_connection.return_value = mock_autocommit_connection
         from src.gold.aggregator import GoldAggregator
@@ -203,9 +206,11 @@ class TestEnsurePartition:
         agg._ensure_partition(date(2025, 1, 15))
 
         agg.db_connector.get_autocommit_connection.assert_called_once_with()
+        mock_autocommit_connection.__enter__.assert_called_once_with()
+        mock_autocommit_connection.__exit__.assert_called_once()
         mock_session.execute.assert_not_called()
-        mock_autocommit_connection.execute.assert_called_once()
-        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
+        mock_autocommit_connection.connection.execute.assert_called_once()
+        ddl_text = str(mock_autocommit_connection.connection.execute.call_args[0][0])
         assert "srv_daily_review_list_2025_01_15" in ddl_text
         assert "PARTITION OF public.srv_daily_review_list" in ddl_text
 
@@ -217,11 +222,11 @@ class TestEnsurePartition:
 
         agg._ensure_partition(date(2025, 1, 15))
 
-        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
+        ddl_text = str(mock_autocommit_connection.connection.execute.call_args[0][0])
         assert "2025-01-15" in ddl_text
         assert "2025-01-16" in ddl_text
         # 파라미터 dict 없이 단일 인자로 호출됨
-        assert len(mock_autocommit_connection.execute.call_args[0]) == 1
+        assert len(mock_autocommit_connection.connection.execute.call_args[0]) == 1
 
     def test_ensure_partition_month_boundary(
         self, mock_session, mock_autocommit_connection
@@ -230,7 +235,7 @@ class TestEnsurePartition:
 
         agg._ensure_partition(date(2025, 1, 31))
 
-        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
+        ddl_text = str(mock_autocommit_connection.connection.execute.call_args[0][0])
         assert "2025-01-31" in ddl_text
         assert "2025-02-01" in ddl_text
 
@@ -241,7 +246,7 @@ class TestEnsurePartition:
 
         agg._ensure_partition(date(2025, 1, 15))
 
-        ddl_text = str(mock_autocommit_connection.execute.call_args[0][0])
+        ddl_text = str(mock_autocommit_connection.connection.execute.call_args[0][0])
         assert "public.srv_daily_review_list_2025_01_15" in ddl_text
 
 
@@ -270,7 +275,7 @@ class TestUpsertQueries:
     def test_srv_daily_review_list_executes_sql(self, mock_session, mock_autocommit_connection):
         agg = _make_aggregator(mock_session, mock_autocommit_connection)
         agg._upsert_srv_daily_review_list(mock_session, date(2025, 1, 15))
-        mock_autocommit_connection.execute.assert_called_once()
+        mock_autocommit_connection.connection.execute.assert_called_once()
         assert mock_session.execute.call_count == 1
 
 


### PR DESCRIPTION
## Summary
- add an autocommit connection helper to DatabaseConnector for immediate DDL commits
- move srv_daily_review_list partition creation out of the aggregation transaction
- update aggregator tests to verify partition DDL uses the autocommit path

## Root cause
Partition creation DDL was executed inside the aggregation transaction, which could hold an ACCESS EXCLUSIVE lock on the parent partitioned table longer than necessary.

## Validation
- uv run python -m pytest tests/test_gold_aggregator.py -q

Closes #64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal database connection handling for improved transaction management and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->