### PR TITLE
[codex] add explicit aggregate backfill range

### DIFF
--- a/dags/financial_review_pipeline.py
+++ b/dags/financial_review_pipeline.py
@@ -81,9 +81,9 @@ gold_analyze = BashOperator(
     execution_timeout=timedelta(hours=3),
 )
 
-# Step 5: Gold 집계 (드레인 모드)
-# ANALYZED 레코드의 모든 distinct 날짜를 집계 — gold_analyze가 날짜 무관하게 전체
-# 드레인하므로, 재시도로 이전 날짜 리뷰가 ANALYZED 되더라도 집계 누락 방지.
+# Step 5: Gold 집계
+# 기본은 DAG 실행일 기준 단일 날짜 집계.
+# 과거 날짜 복구가 필요할 때만 start_date/end_date 범위 백필을 수동 실행한다.
 # UPSERT: fact_service_review_daily, fact_service_aspect_daily,
 #          fact_category_radar_scores, srv_daily_review_list
 gold_aggregate = BashOperator(
@@ -91,7 +91,7 @@ gold_aggregate = BashOperator(
     bash_command=(
         f"cd {PROJECT_ROOT} && PYTHONPATH=. {PYTHON_BIN} -c "
         '"from src.pipeline.steps import run_aggregate; import sys; '
-        "r = run_aggregate(); "
+        "r = run_aggregate(target_date='{{ ds }}'); "
         "print(r.as_dict()); "
         "sys.exit(0 if r.status == 'success' else 1)\""
     ),

--- a/docs/superpowers/plans/2026-04-18-aggregate-range-backfill.md
+++ b/docs/superpowers/plans/2026-04-18-aggregate-range-backfill.md
@@ -1,0 +1,39 @@
+# Aggregate Range Backfill Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restore single-date scheduled aggregation and add an explicit date-range backfill utility for manual repair.
+
+**Architecture:** Keep `GoldAggregator.run()` as the daily path, introduce `run_range()` for bounded multi-date backfills, and route `run_aggregate()` based on explicit arguments. Preserve the old `run_all()` only as an intentional full backfill helper.
+
+**Tech Stack:** Python, pytest, Airflow BashOperator, SQLAlchemy
+
+---
+
+### Task 1: Lock the new aggregate interface in tests
+
+**Files:**
+- Modify: `tests/test_gold_aggregator.py`
+- Create: `tests/test_pipeline_steps.py`
+
+- [ ] Add failing tests for bounded range aggregation and aggregate argument validation.
+- [ ] Run `PYTHONPATH=. uv run pytest tests/test_gold_aggregator.py tests/test_pipeline_steps.py -q` and confirm the new tests fail for missing `run_range` and missing argument handling.
+
+### Task 2: Implement bounded range aggregation
+
+**Files:**
+- Modify: `src/gold/aggregator.py`
+
+- [ ] Add `run_range(start_date, end_date)` and extend `_fetch_analyzed_dates()` with optional range bounds.
+- [ ] Keep `run_all()` as an explicit full backfill wrapper.
+- [ ] Re-run `PYTHONPATH=. uv run pytest tests/test_gold_aggregator.py tests/test_pipeline_steps.py -q`.
+
+### Task 3: Restore scheduled single-date aggregation
+
+**Files:**
+- Modify: `src/pipeline/steps.py`
+- Modify: `dags/financial_review_pipeline.py`
+
+- [ ] Update `run_aggregate()` to dispatch to `run`, `run_range`, or fail on invalid combinations.
+- [ ] Restore the DAG command to `run_aggregate(target_date='{{ ds }}')`.
+- [ ] Re-run `PYTHONPATH=. uv run pytest tests/test_gold_aggregator.py tests/test_pipeline_steps.py -q`.

--- a/docs/superpowers/specs/2026-04-18-aggregate-range-backfill-design.md
+++ b/docs/superpowers/specs/2026-04-18-aggregate-range-backfill-design.md
@@ -1,0 +1,14 @@
+# Aggregate Range Backfill Design
+
+**Goal:** Restore the daily aggregate path as the default Airflow behavior and keep a bounded manual backfill utility for exceptional aggregate repair.
+
+**Design:**
+- `gold_aggregate` in Airflow goes back to `target_date='{{ ds }}'`, so scheduled runs aggregate only the logical execution date.
+- `run_aggregate()` accepts either `target_date` or an explicit `start_date`/`end_date` pair for manual backfills.
+- `GoldAggregator` adds `run_range(start_date, end_date)` and reuses the existing per-date commit flow, but only for `ANALYZED` dates inside the requested bounds.
+- `run_all()` remains available as an explicit full backfill helper, but it is no longer the implicit default path.
+
+**Why this approach:**
+- The team expects aggregate repair to be rare, so always scanning all analyzed dates is unnecessary operational cost.
+- Explicit range parameters make exceptional repair obvious and auditable.
+- No schema or state-machine changes are needed.

--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -99,28 +99,40 @@ class GoldAggregator:
         )
         return {"date": str(target_date), "tables_updated": updated, "dropped_partitions": dropped}
 
-    def run_all(self, retention_days: int = 14) -> dict:
-        """ANALYZED 레코드의 모든 distinct 날짜를 집계 (드레인 모드).
+    def run_range(
+        self,
+        start_date: date,
+        end_date: date,
+        retention_days: int = 14,
+    ) -> dict:
+        """ANALYZED 레코드 중 지정 날짜 범위만 집계.
 
-        gold_analyze가 날짜 무관하게 전체 드레인하기 때문에, 재시도로 이전 날짜
-        리뷰가 ANALYZED 되더라도 해당 날짜 집계가 누락되지 않도록 보장합니다.
-
-        날짜별로 독립 커밋하여 중간 실패 시에도 성공한 날짜의 진행 상황을 보존합니다.
-        모든 날짜 집계가 성공한 경우에만 TTL 파티션 삭제를 별도 트랜잭션으로 실행합니다.
-
-        Returns:
-            {"dates": list[str], "failed_dates": list[str], "tables_updated": list[str], "dropped_partitions": int}
+        예외 상황에서 과거 날짜를 명시적으로 재집계할 수 있도록 범위를 제한한다.
+        날짜별로 독립 커밋하여 중간 실패 시에도 성공한 날짜의 진행 상황을 보존한다.
         """
+        if start_date > end_date:
+            raise ValueError("start_date must be on or before end_date")
+
         session = self.db_connector.get_session()
         updated_dates: List[str] = []
         failed_dates: List[str] = []
         try:
-            dates = self._fetch_analyzed_dates(session)
+            dates = self._fetch_analyzed_dates(
+                session,
+                start_date=start_date,
+                end_date=end_date,
+            )
             if not dates:
-                self.logger.info("Gold Aggregator run_all: 집계 대상 날짜 없음")
+                self.logger.info(
+                    "Gold Aggregator run_range: 집계 대상 날짜 없음 "
+                    f"(start_date={start_date}, end_date={end_date})"
+                )
                 return {"dates": [], "failed_dates": [], "tables_updated": [], "dropped_partitions": 0}
 
-            self.logger.info(f"Gold Aggregator run_all: {len(dates)}개 날짜 집계 시작")
+            self.logger.info(
+                "Gold Aggregator run_range: "
+                f"{len(dates)}개 날짜 집계 시작 (start_date={start_date}, end_date={end_date})"
+            )
             for d in dates:
                 try:
                     self._upsert_fact_service_review_daily(session, d)
@@ -131,15 +143,15 @@ class GoldAggregator:
                     updated_dates.append(str(d))
                 except Exception:
                     session.rollback()
-                    self.logger.exception(f"Gold Aggregator run_all 날짜 집계 실패, 스킵: date={d}")
+                    self.logger.exception(f"Gold Aggregator run_range 날짜 집계 실패, 스킵: date={d}")
                     failed_dates.append(str(d))
 
             self.logger.info(
-                f"Gold Aggregator run_all 완료: updated={updated_dates}, failed={failed_dates}"
+                f"Gold Aggregator run_range 완료: updated={updated_dates}, failed={failed_dates}"
             )
             if failed_dates:
                 raise RuntimeError(
-                    f"Gold Aggregator run_all: 일부 날짜 집계 실패 {failed_dates} "
+                    f"Gold Aggregator run_range: 일부 날짜 집계 실패 {failed_dates} "
                     f"(성공: {updated_dates})"
                 )
         finally:
@@ -157,7 +169,7 @@ class GoldAggregator:
             finally:
                 session.close()
         except Exception:
-            self.logger.exception("run_all TTL 파티션 삭제 실패(집계는 성공 커밋됨)")
+            self.logger.exception("run_range TTL 파티션 삭제 실패(집계는 성공 커밋됨)")
 
         return {
             "dates": updated_dates,
@@ -171,20 +183,47 @@ class GoldAggregator:
             "dropped_partitions": dropped,
         }
 
+    def run_all(self, retention_days: int = 14) -> dict:
+        """ANALYZED 레코드의 모든 distinct 날짜를 집계.
+
+        전체 백필이 필요할 때만 명시적으로 사용한다.
+        """
+        return self.run_range(
+            start_date=date.min,
+            end_date=date.max,
+            retention_days=retention_days,
+        )
+
     # ------------------------------------------------------------------
     # Per-table UPSERT helpers
     # ------------------------------------------------------------------
 
-    def _fetch_analyzed_dates(self, session) -> List[date]:
-        """ANALYZED 레코드가 존재하는 모든 distinct 날짜 조회."""
-        sql = text("""
+    def _fetch_analyzed_dates(
+        self,
+        session,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+    ) -> List[date]:
+        """ANALYZED 레코드가 존재하는 distinct 날짜 조회."""
+        clauses = [
+            "processing_status = 'ANALYZED'",
+            "review_created_at IS NOT NULL",
+        ]
+        params = {}
+        if start_date is not None:
+            clauses.append("DATE_TRUNC('day', review_created_at)::date >= :start_date")
+            params["start_date"] = start_date
+        if end_date is not None:
+            clauses.append("DATE_TRUNC('day', review_created_at)::date <= :end_date")
+            params["end_date"] = end_date
+
+        sql = text(f"""
             SELECT DISTINCT DATE_TRUNC('day', review_created_at)::date AS d
             FROM review_master_index
-            WHERE processing_status = 'ANALYZED'
-              AND review_created_at IS NOT NULL
+            WHERE {' AND '.join(clauses)}
             ORDER BY d
         """)
-        return [row.d for row in session.execute(sql)]
+        return [row.d for row in session.execute(sql, params)]
 
     def _drop_old_partitions(self, session, retention_days: int = 14) -> int:
         """retention_days 초과 파티션 DROP.

--- a/src/pipeline/steps.py
+++ b/src/pipeline/steps.py
@@ -83,21 +83,47 @@ def run_gold(batch_size: int = 100, limit: Optional[int] = None, config_path: Op
     return _handle_step("gold", _run)
 
 
-def run_aggregate(target_date: Optional[str] = None, config_path: Optional[str] = None) -> RunResult:
-    """Run Gold Layer aggregation step (fact tables + serving mart).
-
-    target_date 미지정 시 드레인 모드: ANALYZED 레코드의 모든 distinct 날짜를 집계.
-    gold_analyze가 날짜 무관하게 전체 드레인하므로, 재시도로 이전 날짜 리뷰가
-    ANALYZED 되더라도 집계 누락이 발생하지 않습니다.
-    """
+def run_aggregate(
+    target_date: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    config_path: Optional[str] = None,
+) -> RunResult:
+    """Run Gold Layer aggregation step (fact tables + serving mart)."""
     from src.gold.aggregator import GoldAggregator
+    from datetime import date as _date
+    from datetime import datetime
+
+    if target_date and (start_date or end_date):
+        return RunResult(
+            step="aggregate",
+            status="failed",
+            message="target_date cannot be combined with start_date/end_date",
+        )
+
+    if bool(start_date) ^ bool(end_date):
+        return RunResult(
+            step="aggregate",
+            status="failed",
+            message="start_date and end_date must be provided together",
+        )
 
     if target_date:
-        from datetime import datetime
         parsed_date = datetime.strptime(target_date, "%Y-%m-%d").date()
         return _handle_step("aggregate", lambda: GoldAggregator(config_path).run(target_date=parsed_date))
 
-    return _handle_step("aggregate", lambda: GoldAggregator(config_path).run_all())
+    if start_date and end_date:
+        parsed_start = datetime.strptime(start_date, "%Y-%m-%d").date()
+        parsed_end = datetime.strptime(end_date, "%Y-%m-%d").date()
+        return _handle_step(
+            "aggregate",
+            lambda: GoldAggregator(config_path).run_range(
+                start_date=parsed_start,
+                end_date=parsed_end,
+            ),
+        )
+
+    return _handle_step("aggregate", lambda: GoldAggregator(config_path).run(target_date=_date.today()))
 
 
 def run_load(batch_size: int = 100, config_path: Optional[str] = None) -> RunResult:

--- a/src/pipeline/steps.py
+++ b/src/pipeline/steps.py
@@ -94,6 +94,12 @@ def run_aggregate(
     from datetime import date as _date
     from datetime import datetime
 
+    def _parse_date_arg(arg_name: str, value: str):
+        try:
+            return datetime.strptime(value, "%Y-%m-%d").date()
+        except ValueError:
+            raise ValueError(f"Invalid {arg_name}: {value!r}. Expected YYYY-MM-DD.") from None
+
     if target_date and (start_date or end_date):
         return RunResult(
             step="aggregate",
@@ -109,12 +115,18 @@ def run_aggregate(
         )
 
     if target_date:
-        parsed_date = datetime.strptime(target_date, "%Y-%m-%d").date()
+        try:
+            parsed_date = _parse_date_arg("target_date", target_date)
+        except ValueError as exc:
+            return RunResult(step="aggregate", status="failed", message=str(exc))
         return _handle_step("aggregate", lambda: GoldAggregator(config_path).run(target_date=parsed_date))
 
     if start_date and end_date:
-        parsed_start = datetime.strptime(start_date, "%Y-%m-%d").date()
-        parsed_end = datetime.strptime(end_date, "%Y-%m-%d").date()
+        try:
+            parsed_start = _parse_date_arg("start_date", start_date)
+            parsed_end = _parse_date_arg("end_date", end_date)
+        except ValueError as exc:
+            return RunResult(step="aggregate", status="failed", message=str(exc))
         return _handle_step(
             "aggregate",
             lambda: GoldAggregator(config_path).run_range(

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -100,11 +100,11 @@ class TestRun:
 
 
 # ---------------------------------------------------------------------------
-# run_all() — #57 드레인 모드
+# run_range() / run_all()
 # ---------------------------------------------------------------------------
 
-class TestRunAll:
-    def test_run_all_aggregates_all_analyzed_dates(self, mock_session):
+class TestRunRange:
+    def test_run_range_aggregates_only_bounded_analyzed_dates(self, mock_session):
         agg = _make_aggregator(mock_session)
         dates = [date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15)]
         agg._fetch_analyzed_dates = MagicMock(return_value=dates)
@@ -114,8 +114,13 @@ class TestRunAll:
         agg._upsert_srv_daily_review_list = MagicMock()
         agg._drop_old_partitions = MagicMock(return_value=2)
 
-        result = agg.run_all()
+        result = agg.run_range(date(2025, 1, 13), date(2025, 1, 15))
 
+        agg._fetch_analyzed_dates.assert_called_once_with(
+            mock_session,
+            start_date=date(2025, 1, 13),
+            end_date=date(2025, 1, 15),
+        )
         assert agg._upsert_fact_service_review_daily.call_count == 3
         assert agg._upsert_srv_daily_review_list.call_count == 3
         assert result["dates"] == ["2025-01-13", "2025-01-14", "2025-01-15"]
@@ -123,18 +128,18 @@ class TestRunAll:
         assert "fact_service_review_daily" in result["tables_updated"]
         assert result["dropped_partitions"] == 2
 
-    def test_run_all_empty_returns_early(self, mock_session):
+    def test_run_range_empty_returns_early(self, mock_session):
         agg = _make_aggregator(mock_session)
         agg._fetch_analyzed_dates = MagicMock(return_value=[])
 
-        result = agg.run_all()
+        result = agg.run_range(date(2025, 1, 13), date(2025, 1, 15))
 
         assert result["dates"] == []
         assert result["failed_dates"] == []
         assert result["dropped_partitions"] == 0
         mock_session.commit.assert_not_called()
 
-    def test_run_all_commits_per_date(self, mock_session):
+    def test_run_range_commits_per_date(self, mock_session):
         """날짜별 독립 커밋 3회 + TTL 커밋 1회 = 총 4회."""
         agg = _make_aggregator(mock_session)
         agg._fetch_analyzed_dates = MagicMock(
@@ -149,12 +154,12 @@ class TestRunAll:
         ):
             setattr(agg, method, MagicMock(return_value=0))
 
-        agg.run_all()
+        agg.run_range(date(2025, 1, 13), date(2025, 1, 15))
 
         assert mock_session.commit.call_count == 4  # 3 per-date + 1 TTL
         assert mock_session.close.call_count == 2   # 집계 세션 + TTL 세션
 
-    def test_run_all_raises_if_any_date_failed(self, mock_session):
+    def test_run_range_raises_if_any_date_failed(self, mock_session):
         """실패 날짜 존재 시 RuntimeError — DAG가 실패로 인식하도록."""
         agg = _make_aggregator(mock_session)
         dates = [date(2025, 1, 13), date(2025, 1, 14), date(2025, 1, 15)]
@@ -169,12 +174,33 @@ class TestRunAll:
         agg._upsert_srv_daily_review_list = MagicMock()
 
         with pytest.raises(RuntimeError, match="2025-01-14"):
-            agg.run_all()
+            agg.run_range(date(2025, 1, 13), date(2025, 1, 15))
 
         # 성공 날짜는 이미 commit, 실패 날짜는 rollback — 부분 성공 보존됨
         assert mock_session.commit.call_count == 2
         assert mock_session.rollback.call_count == 1
         mock_session.close.assert_called_once()
+
+    def test_run_range_rejects_reversed_bounds(self, mock_session):
+        agg = _make_aggregator(mock_session)
+
+        with pytest.raises(ValueError, match="start_date must be on or before end_date"):
+            agg.run_range(date(2025, 1, 15), date(2025, 1, 13))
+
+
+class TestRunAll:
+    def test_run_all_delegates_to_full_range_fetch(self, mock_session):
+        agg = _make_aggregator(mock_session)
+        agg._fetch_analyzed_dates = MagicMock(return_value=[])
+
+        result = agg.run_all()
+
+        agg._fetch_analyzed_dates.assert_called_once_with(
+            mock_session,
+            start_date=date.min,
+            end_date=date.max,
+        )
+        assert result["dates"] == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -1,0 +1,47 @@
+from unittest.mock import MagicMock, patch
+
+from src.pipeline.steps import run_aggregate
+
+
+@patch("src.gold.aggregator.GoldAggregator")
+def test_run_aggregate_uses_target_date_by_default(mock_aggregator):
+    instance = mock_aggregator.return_value
+    instance.run = MagicMock()
+
+    result = run_aggregate(target_date="2025-01-15")
+
+    instance.run.assert_called_once()
+    assert str(instance.run.call_args.kwargs["target_date"]) == "2025-01-15"
+    assert result.status == "success"
+
+
+@patch("src.gold.aggregator.GoldAggregator")
+def test_run_aggregate_uses_date_range_when_provided(mock_aggregator):
+    instance = mock_aggregator.return_value
+    instance.run_range = MagicMock()
+
+    result = run_aggregate(start_date="2025-01-10", end_date="2025-01-15")
+
+    instance.run_range.assert_called_once()
+    kwargs = instance.run_range.call_args.kwargs
+    assert str(kwargs["start_date"]) == "2025-01-10"
+    assert str(kwargs["end_date"]) == "2025-01-15"
+    assert result.status == "success"
+
+
+def test_run_aggregate_rejects_mixing_target_date_and_range():
+    result = run_aggregate(
+        target_date="2025-01-15",
+        start_date="2025-01-10",
+        end_date="2025-01-15",
+    )
+
+    assert result.status == "failed"
+    assert "target_date cannot be combined" in result.message
+
+
+def test_run_aggregate_requires_complete_range():
+    result = run_aggregate(start_date="2025-01-10")
+
+    assert result.status == "failed"
+    assert "start_date and end_date must be provided together" in result.message

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -45,3 +45,17 @@ def test_run_aggregate_requires_complete_range():
 
     assert result.status == "failed"
     assert "start_date and end_date must be provided together" in result.message
+
+
+def test_run_aggregate_returns_failed_result_for_invalid_target_date():
+    result = run_aggregate(target_date="2025/01/15")
+
+    assert result.status == "failed"
+    assert "YYYY-MM-DD" in result.message
+
+
+def test_run_aggregate_returns_failed_result_for_invalid_range_date():
+    result = run_aggregate(start_date="2025-01-10", end_date="bad-date")
+
+    assert result.status == "failed"
+    assert "YYYY-MM-DD" in result.message


### PR DESCRIPTION
## Summary
- restore scheduled aggregate runs to the DAG execution date
- add explicit start_date/end_date backfill support for manual aggregate repair
- keep full run_all backfill available as an intentional utility instead of the default path

## Testing
- PYTHONPATH=. uv run pytest tests/test_gold_aggregator.py tests/test_pipeline_steps.py -q


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for bounded date-range aggregation during backfill operations, allowing users to specify custom start and end dates to constrain aggregations to a particular time window.
  * Enhanced single-date aggregation to align with scheduled execution dates.

* **Documentation**
  * Added implementation plan and design specifications for the aggregate range backfill feature, including expected behavior and validation requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->