### PR TITLE
fix: update neutral parquet path examples

### DIFF
--- a/src/utils/parquet_writer.py
+++ b/src/utils/parquet_writer.py
@@ -1,4 +1,4 @@
-"""Parquet writer utility for NAS storage.
+"""Parquet writer utility for local or shared storage.
 
 This module provides utilities for writing Pydantic schemas to Parquet files
 with support for partitioning and batch operations.
@@ -21,8 +21,8 @@ logger = get_logger(__name__)
 class ParquetWriter:
     """Write Pydantic schemas to Parquet files with partitioning support.
 
-    This class handles writing validated Pydantic data to Parquet files on NAS,
-    with support for:
+    This class handles writing validated Pydantic data to Parquet files under
+    the configured base path, with support for:
     - Time-based partitioning (year/month/day)
     - Batch writing for efficiency
     - Schema evolution tracking
@@ -38,7 +38,7 @@ class ParquetWriter:
         >>> from datetime import datetime, timezone
         >>>
         >>> writer = ParquetWriter(
-        ...     base_path="/mnt/nas/bronze/app_reviews",
+        ...     base_path="./data/parquet/bronze/app_reviews",
         ...     partition_by="year_month"
         ... )
         >>>
@@ -201,7 +201,7 @@ class ParquetWriter:
             >>> # With partition_by='year_month' and date=2026-02-04
             >>> path = writer._get_partition_path(datetime(2026, 2, 4))
             >>> str(path)
-            '/mnt/nas/bronze/app_reviews/year=2026/month=02'
+            'data/parquet/bronze/app_reviews/year=2026/month=02'
         """
         if self.partition_by == 'none':
             return self.base_path
@@ -229,8 +229,8 @@ class ParquetWriter:
             >>> partitions = writer.list_partitions()
             >>> for partition in partitions:
             ...     print(partition)
-            /mnt/nas/bronze/app_reviews/year=2026/month=01
-            /mnt/nas/bronze/app_reviews/year=2026/month=02
+            data/parquet/bronze/app_reviews/year=2026/month=01
+            data/parquet/bronze/app_reviews/year=2026/month=02
         """
         if self.partition_by == 'none':
             return [self.base_path]
@@ -301,7 +301,7 @@ def read_parquet_to_schemas(
     Example:
         >>> from src.schemas.parquet import AppReviewSchema
         >>> reviews = read_parquet_to_schemas(
-        ...     "/mnt/nas/bronze/app_reviews/year=2026/month=02/data.parquet",
+        ...     "./data/parquet/bronze/app_reviews/year=2026/month=02/data.parquet",
         ...     AppReviewSchema
         ... )
         >>> print(f"Read {len(reviews)} reviews")

--- a/src/utils/path_resolver.py
+++ b/src/utils/path_resolver.py
@@ -14,8 +14,8 @@ Usage:
     >>> from utils.path_resolver import PathResolver
     >>> resolver = PathResolver()
     >>> bronze_path = resolver.resolve("${PARQUET_BASE_PATH}/bronze")
-    >>> # Returns: "/mnt/nas/reai-data/bronze" (production)
-    >>> # Or: "./data/parquet/bronze" (development)
+    >>> # Returns: "./data/parquet/bronze" by default
+    >>> # Or a custom path when PARQUET_BASE_PATH is set
 """
 
 import os
@@ -65,7 +65,7 @@ class PathResolver:
         """
         env_vars = {}
 
-        # PARQUET_BASE_PATH (critical for NAS-first architecture)
+        # PARQUET_BASE_PATH (local by default, override for shared storage)
         env_vars['PARQUET_BASE_PATH'] = os.getenv(
             'PARQUET_BASE_PATH',
             self.default_base_path
@@ -94,7 +94,7 @@ class PathResolver:
 
         Examples:
             >>> resolver.resolve("${PARQUET_BASE_PATH}/bronze")
-            '/mnt/nas/reai-data/bronze'
+            './data/parquet/bronze'
 
             >>> resolver.resolve("data/raw")
             'data/raw'
@@ -181,7 +181,7 @@ class PathResolver:
 
         Examples:
             >>> resolver.get_path('bronze_dir')
-            Path('/mnt/nas/reai-data/bronze')
+            Path('data/parquet/bronze')
         """
         config = self.load_config()
 

--- a/src/utils/path_resolver.py
+++ b/src/utils/path_resolver.py
@@ -11,7 +11,7 @@ Features:
 - YAML config file support
 
 Usage:
-    >>> from utils.path_resolver import PathResolver
+    >>> from src.utils.path_resolver import PathResolver
     >>> resolver = PathResolver()
     >>> bronze_path = resolver.resolve("${PARQUET_BASE_PATH}/bronze")
     >>> # Returns: "./data/parquet/bronze" by default
@@ -180,8 +180,8 @@ class PathResolver:
             KeyError: If key not found in config
 
         Examples:
-            >>> resolver.get_path('bronze_dir')
-            Path('data/parquet/bronze')
+            >>> str(resolver.get_path('bronze_dir'))
+            'data/parquet/bronze'
         """
         config = self.load_config()
 
@@ -257,7 +257,7 @@ def resolve_path(path_str: str, create_if_missing: bool = False) -> Path:
         Resolved Path object
 
     Examples:
-        >>> from utils.path_resolver import resolve_path
+        >>> from src.utils.path_resolver import resolve_path
         >>> bronze = resolve_path("${PARQUET_BASE_PATH}/bronze", create_if_missing=True)
     """
     resolver = get_resolver()
@@ -274,7 +274,7 @@ def get_medallion_paths(create_if_missing: bool = True) -> Dict[str, Path]:
         Dictionary with keys: bronze_dir, silver_dir, gold_dir
 
     Examples:
-        >>> from utils.path_resolver import get_medallion_paths
+        >>> from src.utils.path_resolver import get_medallion_paths
         >>> paths = get_medallion_paths()
         >>> bronze = paths['bronze_dir']
     """


### PR DESCRIPTION
## Summary
- Replace NAS-specific parquet path examples with environment-neutral local parquet examples
- Reword adjacent NAS-first docstring/comment text to describe configurable storage paths

## Why
The previous examples made it look like /mnt/nas paths were required for local development or usage. These examples now match the default ./data/parquet behavior while preserving support for custom PARQUET_BASE_PATH values.

Closes #62

## Validation
- PYTHONPATH=. uv run pytest tests/test_path_resolver.py tests/test_parquet_writer.py
  - 37 passed, 1 warning
- uv test
  - Not supported by installed uv: unrecognized subcommand 'test'
- PYTHONPATH=. uv run pytest
  - Collection blocked by existing ImportError in tests/test_crawler_consistency.py: missing DBCommitError from src.crawlers.appstore_crawler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs, examples, and doctests to use local-by-default Parquet storage (`./data/parquet`) instead of NAS paths.
  * Adjusted example outputs and formatting in documentation to reflect the new default base path and local-first wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->