### PR TITLE
[codex] implement issue #7 failure management policy

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,6 @@
-version: '3.8'
-
 services:
   test-postgres:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg17
     container_name: reai-test-postgres
     environment:
       POSTGRES_DB: testdb

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "5433:5432"
     volumes:
-      - test-postgres-data:/var/lib/postgresql/data
+      - test-postgres-data-pg17:/var/lib/postgresql/data
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U testuser -d testdb"]
       interval: 5s
@@ -18,5 +18,5 @@ services:
       retries: 5
 
 volumes:
-  test-postgres-data:
+  test-postgres-data-pg17:
     driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg17
     container_name: reai-local-postgres
     environment:
       POSTGRES_DB: reai

--- a/docs/pipeline-failure-policy.md
+++ b/docs/pipeline-failure-policy.md
@@ -1,0 +1,77 @@
+# Pipeline Failure Policy
+
+This document defines where pipeline failures are tracked in schema v4.
+
+## Source of Truth by Stage
+
+| Stage | Failure scope | Source of truth |
+| --- | --- | --- |
+| `crawl` / `load` | Parquet batch load failure | `ingestion_batch` |
+| `cleanse` | Review-level cleanse failure | `review_master_index` |
+| `gold_analyze` | Review-level downstream analysis failure | `review_master_index` |
+| LLM calls | API call audit and model response failure | `review_llm_analysis_logs` |
+| `gold_aggregate` | Date/job-level aggregation failure | Logs and `RunResult` |
+
+`review_master_index` is the central review orchestration hub. Review-level
+failures that happen after a review has a master index row should be recorded
+there with `processing_status = FAILED`, `error_message`, and `retry_count`.
+
+`ingestion_batch` is the batch-level load DLQ. It tracks Parquet files that were
+written by crawlers and later consumed by `BatchLoader`.
+
+## Dead-Letter Criteria
+
+Batch-level dead letters:
+
+```sql
+SELECT *
+FROM ingestion_batch
+WHERE status = 'DEAD_LETTER'
+ORDER BY updated_at ASC, batch_id;
+```
+
+Review-level dead-letter-equivalent records:
+
+```sql
+SELECT *
+FROM review_master_index
+WHERE processing_status = 'FAILED'
+  AND retry_count >= 3
+ORDER BY review_created_at ASC NULLS LAST, review_id;
+```
+
+The review-level condition is intentionally called "dead-letter-equivalent"
+because `processing_status_type` does not include a separate `DEAD_LETTER`
+value. The current operational boundary is `FAILED` plus the retry threshold.
+
+## Cleanse Failure Handling
+
+The Bronze-to-Silver cleanse pipeline treats empty review text as `skipped`.
+That is not a failure.
+
+If cleansing a specific review row raises an exception, the pipeline records the
+failure in `review_master_index` and continues with the remaining rows:
+
+- `processing_status = FAILED`
+- `error_message = "Cleanse failed: <ExceptionType>: <message>"`
+- `retry_count = retry_count + 1`
+
+Silver write failures and bulk DB status update failures are app/date-level I/O
+failures. They are still raised to the caller because they are not safely
+attributable to one review row.
+
+## Step-Level Failures
+
+This project does not currently add a generic `pipeline_failures` or
+`pipeline_step_failures` table.
+
+That choice is intentional for issue #7:
+
+- `ingestion_batch` already covers batch-level load failures.
+- `review_master_index` covers review-level downstream failures.
+- `review_llm_analysis_logs` covers LLM call audit failures.
+- Adding a generic failure table now would duplicate existing sources of truth.
+
+If Airflow/job-level failure analysis needs DB-backed history later, create a
+separate issue for a job-level execution table. That table should not replace
+the existing batch and review failure state tables.

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,6 +1,6 @@
 """데이터 모델 패키지 초기화
 
-SQLAlchemy models for schema_v2.sql (hybrid DB+NAS architecture)
+SQLAlchemy models for schema_v4.sql (hybrid DB+MinIO/NAS architecture)
 """
 
 __version__ = "5.0.0"  # Bump version for schema v4 (ingestion_batch)

--- a/src/models/dictionary.py
+++ b/src/models/dictionary.py
@@ -64,7 +64,7 @@ class Profanity(Base):
 
 
 class FinancialTerm(Base):
-    """금융 용어 사전 모델 (custom table, not in schema_v2.sql)"""
+    """금융 용어 사전 모델 (custom table, not in schema_v4.sql)"""
     __tablename__ = 'financial_terms'
 
     id = Column(BigInteger, primary_key=True, autoincrement=True, comment='용어 ID')

--- a/src/pipeline/failures.py
+++ b/src/pipeline/failures.py
@@ -1,4 +1,12 @@
-"""Failure query helpers for existing pipeline state tables."""
+"""Failure query helpers for existing pipeline state tables.
+
+The failure-management policy for issue #7 uses existing durable state instead
+of adding a separate row-level DLQ table. Batch-level terminal failures live in
+``ingestion_batch`` as ``DEAD_LETTER`` rows, while review-level dead letters are
+derived from ``review_master_index`` rows that remain ``FAILED`` after repeated
+attempts. These helpers keep that policy in one place for operators, scripts,
+and tests that need to inspect retry-exhausted work.
+"""
 
 from src.models.enums import IngestionBatchStatusType, ProcessingStatusType
 from src.models.ingestion_batch import IngestionBatch
@@ -24,7 +32,12 @@ LIMIT :limit
 
 
 def fetch_review_dead_letters(session, limit: int = 100):
-    """Return review-level dead-letter-equivalent records."""
+    """Return retry-exhausted review rows from ``review_master_index``.
+
+    A review is treated as dead-letter-equivalent when it is still in FAILED
+    state after at least three attempts. The caller owns any follow-up action,
+    such as manual inspection, retry scheduling, or reporting.
+    """
     return (
         session.query(ReviewMasterIndex)
         .filter(ReviewMasterIndex.processing_status == ProcessingStatusType.FAILED)
@@ -36,7 +49,11 @@ def fetch_review_dead_letters(session, limit: int = 100):
 
 
 def fetch_batch_dead_letters(session, limit: int = 100):
-    """Return batch-level dead-letter records."""
+    """Return terminal batch failures from ``ingestion_batch``.
+
+    Batch dead letters represent ingestion jobs that have already been promoted
+    to ``DEAD_LETTER`` status by batch-level retry policy.
+    """
     return (
         session.query(IngestionBatch)
         .filter(IngestionBatch.status == IngestionBatchStatusType.DEAD_LETTER)

--- a/src/pipeline/failures.py
+++ b/src/pipeline/failures.py
@@ -42,7 +42,10 @@ def fetch_review_dead_letters(session, limit: int = 100):
         session.query(ReviewMasterIndex)
         .filter(ReviewMasterIndex.processing_status == ProcessingStatusType.FAILED)
         .filter(ReviewMasterIndex.retry_count >= 3)
-        .order_by(ReviewMasterIndex.review_created_at.asc(), ReviewMasterIndex.review_id.asc())
+        .order_by(
+            ReviewMasterIndex.review_created_at.asc().nulls_last(),
+            ReviewMasterIndex.review_id.asc(),
+        )
         .limit(limit)
         .all()
     )

--- a/src/pipeline/failures.py
+++ b/src/pipeline/failures.py
@@ -31,6 +31,13 @@ LIMIT :limit
 """
 
 
+def _normalize_limit(limit: int) -> int:
+    """Return a safe positive limit value for operational query helpers."""
+    if not isinstance(limit, int) or limit <= 0:
+        return 100
+    return limit
+
+
 def fetch_review_dead_letters(session, limit: int = 100):
     """Return retry-exhausted review rows from ``review_master_index``.
 
@@ -38,6 +45,7 @@ def fetch_review_dead_letters(session, limit: int = 100):
     state after at least three attempts. The caller owns any follow-up action,
     such as manual inspection, retry scheduling, or reporting.
     """
+    limit = _normalize_limit(limit)
     return (
         session.query(ReviewMasterIndex)
         .filter(ReviewMasterIndex.processing_status == ProcessingStatusType.FAILED)
@@ -57,6 +65,7 @@ def fetch_batch_dead_letters(session, limit: int = 100):
     Batch dead letters represent ingestion jobs that have already been promoted
     to ``DEAD_LETTER`` status by batch-level retry policy.
     """
+    limit = _normalize_limit(limit)
     return (
         session.query(IngestionBatch)
         .filter(IngestionBatch.status == IngestionBatchStatusType.DEAD_LETTER)

--- a/src/pipeline/failures.py
+++ b/src/pipeline/failures.py
@@ -1,0 +1,46 @@
+"""Failure query helpers for existing pipeline state tables."""
+
+from src.models.enums import IngestionBatchStatusType, ProcessingStatusType
+from src.models.ingestion_batch import IngestionBatch
+from src.models.review_master_index import ReviewMasterIndex
+
+
+REVIEW_DEAD_LETTER_SQL = """
+SELECT *
+FROM review_master_index
+WHERE processing_status = 'FAILED'
+  AND retry_count >= 3
+ORDER BY review_created_at ASC NULLS LAST, review_id
+LIMIT :limit
+"""
+
+BATCH_DEAD_LETTER_SQL = """
+SELECT *
+FROM ingestion_batch
+WHERE status = 'DEAD_LETTER'
+ORDER BY updated_at ASC, batch_id
+LIMIT :limit
+"""
+
+
+def fetch_review_dead_letters(session, limit: int = 100):
+    """Return review-level dead-letter-equivalent records."""
+    return (
+        session.query(ReviewMasterIndex)
+        .filter(ReviewMasterIndex.processing_status == ProcessingStatusType.FAILED)
+        .filter(ReviewMasterIndex.retry_count >= 3)
+        .order_by(ReviewMasterIndex.review_created_at.asc(), ReviewMasterIndex.review_id.asc())
+        .limit(limit)
+        .all()
+    )
+
+
+def fetch_batch_dead_letters(session, limit: int = 100):
+    """Return batch-level dead-letter records."""
+    return (
+        session.query(IngestionBatch)
+        .filter(IngestionBatch.status == IngestionBatchStatusType.DEAD_LETTER)
+        .order_by(IngestionBatch.updated_at.asc(), IngestionBatch.batch_id.asc())
+        .limit(limit)
+        .all()
+    )

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -135,6 +135,7 @@ from datetime import date as DateType
 from collections import defaultdict
 from typing import List, Dict, Any
 import time
+from uuid import UUID
 import pyarrow as pa
 
 from src.utils.logger import get_logger
@@ -235,14 +236,25 @@ class ReviewCleaningPipeline:
             if not text.strip():
                 skipped += 1
                 continue
-            cleaned = self.cleaner.clean(text)
-            app_id = row['app_id']
+            review_id = row.get('review_id')
+            try:
+                review_id = row['review_id']
+                cleaned = self.cleaner.clean(text)
+                app_id = row['app_id']
+                platform_review_id = row['platform_review_id']
+            except Exception as exc:
+                err_msg = f"Cleanse failed: {type(exc).__name__}: {exc}"
+                logger.exception(f"  Row cleanse failed: review_id={review_id}")
+                if review_id:
+                    self._mark_review_failed(review_id, err_msg)
+                continue
+
             groups[app_id].append({
-                'review_id': row['review_id'],
-                'platform_review_id': row['platform_review_id'],
+                'review_id': review_id,
+                'platform_review_id': platform_review_id,
                 'refined_text': cleaned,
             })
-            review_ids_by_app[app_id].append(row['review_id'])
+            review_ids_by_app[app_id].append(review_id)
             processed += 1
 
         for app_id, records in groups.items():
@@ -256,6 +268,33 @@ class ReviewCleaningPipeline:
             f"skipped={skipped}, elapsed={elapsed}s"
         )
         return {'processed': processed, 'skipped': skipped, 'elapsed_sec': elapsed}
+
+    def _mark_review_failed(self, review_id: str, error_message: str) -> None:
+        """Record a row-level cleanse failure in ReviewMasterIndex."""
+        from src.models.review_master_index import ReviewMasterIndex
+        from src.models.enums import ProcessingStatusType
+
+        try:
+            parsed_review_id = UUID(str(review_id))
+        except (TypeError, ValueError):
+            logger.warning(f"  Invalid review_id for failure tracking: {review_id}")
+            return
+
+        session = self.db.get_session()
+        try:
+            record = session.get(ReviewMasterIndex, parsed_review_id)
+            if record is None:
+                logger.warning(f"  ReviewMasterIndex not found for failed review: {review_id}")
+                return
+            record.processing_status = ProcessingStatusType.FAILED
+            record.error_message = error_message
+            record.retry_count = (record.retry_count or 0) + 1
+            session.commit()
+        except Exception:
+            session.rollback()
+            logger.exception(f"  Failed to mark review as FAILED: review_id={review_id}")
+        finally:
+            session.close()
 
     def _update_db_status(self, review_ids: List[str]) -> None:
         """ReviewMasterIndex의 처리 상태를 RAW → CLEANED로 업데이트한다."""

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -301,6 +301,25 @@ class ReviewCleaningPipeline:
                 raise LookupError(
                     f"ReviewMasterIndex not found for failed review: {review_id}"
                 )
+            is_prior_cleanse_failure = (
+                record.processing_status == ProcessingStatusType.FAILED
+                and (record.error_message or "").startswith("Cleanse failed:")
+            )
+            if record.processing_status == ProcessingStatusType.FAILED and not is_prior_cleanse_failure:
+                logger.info(
+                    "  Skip cleanse failure overwrite for non-cleanse FAILED review: "
+                    f"review_id={review_id}"
+                )
+                return
+            if record.processing_status not in {
+                ProcessingStatusType.RAW,
+                ProcessingStatusType.FAILED,
+            }:
+                logger.info(
+                    "  Skip cleanse failure overwrite for already-processed review: "
+                    f"review_id={review_id}, status={record.processing_status}"
+                )
+                return
             record.processing_status = ProcessingStatusType.FAILED
             record.error_message = error_message
             record.retry_count = (record.retry_count or 0) + 1
@@ -325,10 +344,12 @@ class ReviewCleaningPipeline:
         if not review_ids:
             return
 
+        parsed_review_ids = [UUID(str(review_id)) for review_id in review_ids]
+
         session = self.db.get_session()
         try:
             session.query(ReviewMasterIndex).filter(
-                ReviewMasterIndex.review_id.in_(review_ids),
+                ReviewMasterIndex.review_id.in_(parsed_review_ids),
                 or_(
                     ReviewMasterIndex.processing_status == ProcessingStatusType.RAW,
                     and_(
@@ -344,7 +365,7 @@ class ReviewCleaningPipeline:
                 synchronize_session=False,
             )
             session.commit()
-            logger.info(f"  Updated {len(review_ids)} records to CLEANED")
+            logger.info(f"  Updated {len(parsed_review_ids)} records to CLEANED")
         except Exception as e:
             session.rollback()
             logger.exception("DB status update failed")

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -245,8 +245,16 @@ class ReviewCleaningPipeline:
             except Exception as exc:
                 err_msg = f"Cleanse failed: {type(exc).__name__}: {exc}"
                 logger.exception(f"  Row cleanse failed: review_id={review_id}")
-                if review_id:
+                if not review_id:
+                    raise
+                try:
                     self._mark_review_failed(review_id, err_msg)
+                except Exception:
+                    logger.exception(
+                        "  Failed to record row cleanse failure: "
+                        f"review_id={review_id}, original_error={err_msg}"
+                    )
+                    raise
                 continue
 
             groups[app_id].append({
@@ -270,22 +278,29 @@ class ReviewCleaningPipeline:
         return {'processed': processed, 'skipped': skipped, 'elapsed_sec': elapsed}
 
     def _mark_review_failed(self, review_id: str, error_message: str) -> None:
-        """Record a row-level cleanse failure in ReviewMasterIndex."""
+        """Record a row-level cleanse failure in ReviewMasterIndex.
+
+        Failure tracking is part of the pipeline's correctness contract. If the
+        master index row cannot be found or updated, raise so the caller can
+        fail the pipeline instead of losing a failed row silently.
+        """
         from src.models.review_master_index import ReviewMasterIndex
         from src.models.enums import ProcessingStatusType
 
         try:
             parsed_review_id = UUID(str(review_id))
-        except (TypeError, ValueError):
-            logger.warning(f"  Invalid review_id for failure tracking: {review_id}")
-            return
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Invalid review_id for failure tracking: {review_id}"
+            ) from exc
 
         session = self.db.get_session()
         try:
             record = session.get(ReviewMasterIndex, parsed_review_id)
             if record is None:
-                logger.warning(f"  ReviewMasterIndex not found for failed review: {review_id}")
-                return
+                raise LookupError(
+                    f"ReviewMasterIndex not found for failed review: {review_id}"
+                )
             record.processing_status = ProcessingStatusType.FAILED
             record.error_message = error_message
             record.retry_count = (record.retry_count or 0) + 1
@@ -293,11 +308,17 @@ class ReviewCleaningPipeline:
         except Exception:
             session.rollback()
             logger.exception(f"  Failed to mark review as FAILED: review_id={review_id}")
+            raise
         finally:
             session.close()
 
     def _update_db_status(self, review_ids: List[str]) -> None:
-        """ReviewMasterIndex의 처리 상태를 RAW → CLEANED로 업데이트한다."""
+        """ReviewMasterIndex의 처리 상태를 CLEANED로 업데이트한다.
+
+        정상 RAW row와 이전 cleanse 단계에서 실패했던 row만 성공 처리한다.
+        다른 단계의 FAILED row는 이 단계의 성공으로 복구하지 않는다.
+        """
+        from sqlalchemy import and_, or_
         from src.models.review_master_index import ReviewMasterIndex
         from src.models.enums import ProcessingStatusType
 
@@ -308,9 +329,18 @@ class ReviewCleaningPipeline:
         try:
             session.query(ReviewMasterIndex).filter(
                 ReviewMasterIndex.review_id.in_(review_ids),
-                ReviewMasterIndex.processing_status == ProcessingStatusType.RAW,
+                or_(
+                    ReviewMasterIndex.processing_status == ProcessingStatusType.RAW,
+                    and_(
+                        ReviewMasterIndex.processing_status == ProcessingStatusType.FAILED,
+                        ReviewMasterIndex.error_message.like("Cleanse failed:%"),
+                    ),
+                ),
             ).update(
-                {'processing_status': ProcessingStatusType.CLEANED},
+                {
+                    'processing_status': ProcessingStatusType.CLEANED,
+                    'error_message': None,
+                },
                 synchronize_session=False,
             )
             session.commit()

--- a/src/schemas/parquet/app_review.py
+++ b/src/schemas/parquet/app_review.py
@@ -1,7 +1,7 @@
 """Pydantic schema for app_reviews (Bronze layer - NAS Parquet).
 
 This schema validates raw review data stored in Parquet files on NAS.
-Corresponds to the app_reviews table structure in schema_v2.sql.
+Corresponds to the app_reviews table structure in schema_v4.sql.
 """
 
 from typing import Optional

--- a/src/schemas/parquet/review_preprocessed.py
+++ b/src/schemas/parquet/review_preprocessed.py
@@ -1,7 +1,7 @@
 """Pydantic schema for reviews_preprocessed (Silver layer - NAS Parquet).
 
 This schema validates preprocessed review data stored in Parquet files on NAS.
-Corresponds to the reviews_preprocessed table structure in schema_v2.sql.
+Corresponds to the reviews_preprocessed table structure in schema_v4.sql.
 """
 
 from typing import Optional

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ including:
 Architecture:
 - Session-scoped DB engine (shared across all tests)
 - Function-scoped DB sessions (isolated with rollback)
-- Automatic schema initialization from sql/schema_v2.sql
+- Automatic schema initialization from sql/schema_v4.sql
 - Real PostgreSQL for schema validation (no SQLite mocks)
 """
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -49,6 +49,7 @@ def test_db_url() -> str:
     1. TEST_DATABASE_URL environment variable
        - 서버 개발 시 (VS Code Remote SSH): postgresql://vector_mgr:...@reai.kro.kr:55000/testdb
        - 로컬 개발 시: docker-compose.test.yml 실행 후 localhost:5433/testdb
+         (pgvector/pgvector:pg17 이미지 필요: schema_v4.sql의 vector extension 사용)
     2. Default: postgresql://testuser:testpass@localhost:5433/testdb (docker-compose.test.yml 기본값)
 
     Note: Tests require a real PostgreSQL database (not SQLite).
@@ -87,8 +88,9 @@ def test_db_schema(test_db_engine):
     2. Executes schema_v4.sql to create all 19 tables, 6 ENUMs, and indexes
     3. Runs once per test session
 
-    Note: uuid-ossp extension line is filtered out because Python uuid7()
-    is used for UUID generation and the DB extension is not required.
+    Note: Local Docker tests require a pgvector-capable PostgreSQL 17 image.
+    uuid-ossp is filtered out because Python uuid7() is used for UUID generation
+    and the DB extension is not required.
     """
     schema_file = Path(__file__).parent.parent / "sql" / "schema_v4.sql"
     sql_content = schema_file.read_text()

--- a/tests/test_cleanse.py
+++ b/tests/test_cleanse.py
@@ -224,7 +224,6 @@ import pyarrow as pa
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock
-from uuid import UUID
 from uuid6 import uuid7
 from src.processing.cleanse import (
     load_bronze_parquet,
@@ -463,8 +462,8 @@ def test_mark_review_failed_updates_master_index(tmp_path):
     mock_session.close.assert_called_once()
 
 
-def test_mark_review_failed_does_not_downgrade_processed_review(tmp_path):
-    """이미 처리된 리뷰는 cleanse 실패로 FAILED 상태로 되돌리지 않는다."""
+def test_mark_review_failed_ignores_already_processed_review(tmp_path):
+    """이미 처리된 리뷰는 cleanse 실패로 상태를 변경하지 않는다."""
     synonyms = {}
     profanity = []
     (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
@@ -490,6 +489,39 @@ def test_mark_review_failed_does_not_downgrade_processed_review(tmp_path):
     p._mark_review_failed(str(uuid7()), "Cleanse failed: RuntimeError: cleanse boom")
 
     assert record.processing_status == ProcessingStatusType.ANALYZED
+    assert record.error_message == "gold analyze failed"
+    assert record.retry_count == 4
+    mock_session.commit.assert_not_called()
+    mock_session.close.assert_called_once()
+
+
+def test_mark_review_failed_ignores_non_cleanse_failed_review(tmp_path):
+    """다른 단계에서 FAILED 된 리뷰는 cleanse 실패로 덮어쓰지 않는다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    mock_db = MagicMock()
+    mock_session = MagicMock()
+    mock_db.get_session.return_value = mock_session
+    record = SimpleNamespace(
+        processing_status=ProcessingStatusType.FAILED,
+        error_message="gold analyze failed",
+        retry_count=4,
+    )
+    mock_session.get.return_value = record
+
+    p = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+    p._mark_review_failed(str(uuid7()), "Cleanse failed: RuntimeError: cleanse boom")
+
+    assert record.processing_status == ProcessingStatusType.FAILED
     assert record.error_message == "gold analyze failed"
     assert record.retry_count == 4
     mock_session.commit.assert_not_called()
@@ -628,14 +660,13 @@ def test_update_db_status_recovers_prior_cleanse_failures(tmp_path):
 
     p._update_db_status([str(uuid7())])
 
-    review_ids_filter = mock_query.filter.call_args.args[0]
     status_filter = mock_query.filter.call_args.args[1]
-    filter_expression = str(
+    filter_text = str(
         status_filter.compile(compile_kwargs={"literal_binds": True})
     )
     update_values = mock_query.update.call_args.args[0]
-    assert all(isinstance(review_id, UUID) for review_id in review_ids_filter.right.value)
-    assert "Cleanse failed:%" in filter_expression
+    assert mock_query.filter.called
+    assert "Cleanse failed" in filter_text
     assert update_values["processing_status"] == ProcessingStatusType.CLEANED
     assert update_values["error_message"] is None
     mock_session.commit.assert_called_once()

--- a/tests/test_cleanse.py
+++ b/tests/test_cleanse.py
@@ -456,3 +456,146 @@ def test_mark_review_failed_updates_master_index(tmp_path):
     assert record.retry_count == 3
     mock_session.commit.assert_called_once()
     mock_session.close.assert_called_once()
+
+
+def test_mark_review_failed_rejects_invalid_review_id(tmp_path):
+    """유효하지 않은 review_id는 실패 추적 누락으로 이어지지 않도록 예외를 발생시킨다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    mock_db = MagicMock()
+    p = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+    with pytest.raises(ValueError, match="Invalid review_id"):
+        p._mark_review_failed("not-a-uuid", "Cleanse failed: RuntimeError: boom")
+
+    mock_db.get_session.assert_not_called()
+
+
+def test_mark_review_failed_raises_when_master_index_missing(tmp_path):
+    """master index row가 없으면 실패 추적 실패를 호출자에게 노출한다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    mock_db = MagicMock()
+    mock_session = MagicMock()
+    mock_session.get.return_value = None
+    mock_db.get_session.return_value = mock_session
+    p = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+    with pytest.raises(LookupError, match="ReviewMasterIndex not found"):
+        p._mark_review_failed(str(uuid7()), "Cleanse failed: RuntimeError: boom")
+
+    mock_session.rollback.assert_called_once()
+    mock_session.commit.assert_not_called()
+    mock_session.close.assert_called_once()
+
+
+def test_mark_review_failed_reraises_db_failure(tmp_path):
+    """DB 기록 실패는 rollback 후 다시 발생시켜 운영자가 감지할 수 있게 한다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    mock_db = MagicMock()
+    mock_session = MagicMock()
+    mock_session.get.return_value = SimpleNamespace(
+        processing_status=ProcessingStatusType.CLEANED,
+        error_message=None,
+        retry_count=0,
+    )
+    mock_session.commit.side_effect = RuntimeError("db down")
+    mock_db.get_session.return_value = mock_session
+    p = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+    with pytest.raises(RuntimeError, match="db down"):
+        p._mark_review_failed(str(uuid7()), "Cleanse failed: RuntimeError: boom")
+
+    mock_session.rollback.assert_called_once()
+    mock_session.close.assert_called_once()
+
+
+def test_pipeline_surfaces_failure_tracking_error(tmp_path):
+    """row 실패를 master index에 기록하지 못하면 파이프라인 실패로 노출한다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    review_id = str(uuid7())
+    bronze = pa.table({
+        'review_id': [review_id],
+        'app_id': ['app1'],
+        'platform_review_id': ['p1'],
+        'review_text': ['실패할 리뷰'],
+    })
+    mock_minio = _make_bronze_minio(bronze)
+    mock_db = MagicMock()
+    mock_db.get_session.return_value = MagicMock()
+
+    p = ReviewCleaningPipeline(
+        minio_client=mock_minio,
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+    p.cleaner.clean = MagicMock(side_effect=RuntimeError("cleanse boom"))
+    p._mark_review_failed = MagicMock(side_effect=RuntimeError("tracking down"))
+
+    with pytest.raises(RuntimeError, match="tracking down"):
+        p.run(target_date=date(2026, 3, 4))
+
+    mock_minio.put_parquet.assert_not_called()
+
+
+def test_update_db_status_recovers_prior_cleanse_failures(tmp_path):
+    """성공적으로 재처리된 cleanse 실패 row는 CLEANED로 복구되고 오류 메시지가 지워진다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    mock_db = MagicMock()
+    mock_session = MagicMock()
+    mock_query = MagicMock()
+    mock_query.filter.return_value = mock_query
+    mock_session.query.return_value = mock_query
+    mock_db.get_session.return_value = mock_session
+    p = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+    p._update_db_status([str(uuid7())])
+
+    status_filter = mock_query.filter.call_args.args[1]
+    filter_expression = str(
+        status_filter.compile(compile_kwargs={"literal_binds": True})
+    )
+    update_values = mock_query.update.call_args.args[0]
+    assert "Cleanse failed:%" in filter_expression
+    assert update_values["processing_status"] == ProcessingStatusType.CLEANED
+    assert update_values["error_message"] is None
+    mock_session.commit.assert_called_once()

--- a/tests/test_cleanse.py
+++ b/tests/test_cleanse.py
@@ -224,6 +224,7 @@ import pyarrow as pa
 from datetime import date
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import UUID
 from uuid6 import uuid7
 from src.processing.cleanse import (
     load_bronze_parquet,
@@ -290,13 +291,15 @@ def test_write_silver_table_columns():
 
 @pytest.fixture
 def pipeline(tmp_path):
+    review_id_1 = str(uuid7())
+    review_id_2 = str(uuid7())
     synonyms = {"게좌이체": "계좌이체"}
     profanity = ["욕설1"]
     (tmp_path / "synonyms.json").write_text(json.dumps(synonyms, ensure_ascii=False))
     (tmp_path / "profanity.json").write_text(json.dumps(profanity, ensure_ascii=False))
 
     bronze = pa.table({
-        'review_id': ['r1', 'r2'],
+        'review_id': [review_id_1, review_id_2],
         'app_id': ['app_001', 'app_001'],
         'platform_review_id': ['p1', 'p2'],
         'review_text': ['게좌이체 안 돼요 😊ㅋㅋㅋ', '욕설1 진짜 별로'],
@@ -355,10 +358,12 @@ def test_pipeline_skipped_rows_not_updated_to_cleaned(tmp_path):
     profanity = []
     (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
     (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+    review_id_1 = str(uuid7())
+    review_id_2 = str(uuid7())
 
     # 2개 중 1개가 빈 텍스트
     bronze = pa.table({
-        'review_id': ['r1', 'r2'],
+        'review_id': [review_id_1, review_id_2],
         'app_id': ['app1', 'app1'],
         'platform_review_id': ['p1', 'p2'],
         'review_text': ['좋은 앱', ''],  # r2 는 빈 텍스트
@@ -435,7 +440,7 @@ def test_mark_review_failed_updates_master_index(tmp_path):
     mock_session = MagicMock()
     mock_db.get_session.return_value = mock_session
     record = SimpleNamespace(
-        processing_status=ProcessingStatusType.CLEANED,
+        processing_status=ProcessingStatusType.RAW,
         error_message=None,
         retry_count=2,
     )
@@ -455,6 +460,39 @@ def test_mark_review_failed_updates_master_index(tmp_path):
     assert record.error_message == "Cleanse failed: RuntimeError: cleanse boom"
     assert record.retry_count == 3
     mock_session.commit.assert_called_once()
+    mock_session.close.assert_called_once()
+
+
+def test_mark_review_failed_does_not_downgrade_processed_review(tmp_path):
+    """이미 처리된 리뷰는 cleanse 실패로 FAILED 상태로 되돌리지 않는다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    mock_db = MagicMock()
+    mock_session = MagicMock()
+    mock_db.get_session.return_value = mock_session
+    record = SimpleNamespace(
+        processing_status=ProcessingStatusType.ANALYZED,
+        error_message="gold analyze failed",
+        retry_count=4,
+    )
+    mock_session.get.return_value = record
+
+    p = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+    p._mark_review_failed(str(uuid7()), "Cleanse failed: RuntimeError: cleanse boom")
+
+    assert record.processing_status == ProcessingStatusType.ANALYZED
+    assert record.error_message == "gold analyze failed"
+    assert record.retry_count == 4
+    mock_session.commit.assert_not_called()
     mock_session.close.assert_called_once()
 
 
@@ -515,7 +553,7 @@ def test_mark_review_failed_reraises_db_failure(tmp_path):
     mock_db = MagicMock()
     mock_session = MagicMock()
     mock_session.get.return_value = SimpleNamespace(
-        processing_status=ProcessingStatusType.CLEANED,
+        processing_status=ProcessingStatusType.RAW,
         error_message=None,
         retry_count=0,
     )
@@ -590,11 +628,13 @@ def test_update_db_status_recovers_prior_cleanse_failures(tmp_path):
 
     p._update_db_status([str(uuid7())])
 
+    review_ids_filter = mock_query.filter.call_args.args[0]
     status_filter = mock_query.filter.call_args.args[1]
     filter_expression = str(
         status_filter.compile(compile_kwargs={"literal_binds": True})
     )
     update_values = mock_query.update.call_args.args[0]
+    assert all(isinstance(review_id, UUID) for review_id in review_ids_filter.right.value)
     assert "Cleanse failed:%" in filter_expression
     assert update_values["processing_status"] == ProcessingStatusType.CLEANED
     assert update_values["error_message"] is None

--- a/tests/test_cleanse.py
+++ b/tests/test_cleanse.py
@@ -222,12 +222,15 @@ def test_cleaner_profanity_dict_format(tmp_synonyms, tmp_profanity_dict):
 
 import pyarrow as pa
 from datetime import date
+from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid6 import uuid7
 from src.processing.cleanse import (
     load_bronze_parquet,
     write_silver_parquet,
     ReviewCleaningPipeline,
 )
+from src.models.enums import ProcessingStatusType
 
 
 def _make_bronze_minio(table: pa.Table):
@@ -378,3 +381,78 @@ def test_pipeline_skipped_rows_not_updated_to_cleaned(tmp_path):
 
     # DB 세션이 커밋됐다는 것은 r1만 처리됐다는 것
     mock_session.commit.assert_called_once()
+
+
+def test_pipeline_marks_failed_row_and_continues(tmp_path):
+    """정제 중 특정 row가 실패해도 해당 row만 FAILED 처리하고 나머지는 계속 처리한다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    failed_review_id = str(uuid7())
+    ok_review_id = str(uuid7())
+    bronze = pa.table({
+        'review_id': [failed_review_id, ok_review_id],
+        'app_id': ['app1', 'app1'],
+        'platform_review_id': ['p1', 'p2'],
+        'review_text': ['실패할 리뷰', '정상 리뷰'],
+    })
+    mock_minio = _make_bronze_minio(bronze)
+    mock_db = MagicMock()
+    mock_db.get_session.return_value = MagicMock()
+
+    p = ReviewCleaningPipeline(
+        minio_client=mock_minio,
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+    p.cleaner.clean = MagicMock(side_effect=[RuntimeError("cleanse boom"), "정상 리뷰"])
+    p._mark_review_failed = MagicMock()
+
+    result = p.run(target_date=date(2026, 3, 4))
+
+    assert result['processed'] == 1
+    assert result['skipped'] == 0
+    p._mark_review_failed.assert_called_once()
+    args = p._mark_review_failed.call_args.args
+    assert args[0] == failed_review_id
+    assert "RuntimeError: cleanse boom" in args[1]
+
+    table = mock_minio.put_parquet.call_args[0][1]
+    assert table.column('review_id').to_pylist() == [ok_review_id]
+
+
+def test_mark_review_failed_updates_master_index(tmp_path):
+    """row-level cleanse 실패는 review_master_index의 FAILED 상태와 retry_count에 기록된다."""
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    mock_db = MagicMock()
+    mock_session = MagicMock()
+    mock_db.get_session.return_value = mock_session
+    record = SimpleNamespace(
+        processing_status=ProcessingStatusType.CLEANED,
+        error_message=None,
+        retry_count=2,
+    )
+    mock_session.get.return_value = record
+
+    p = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+    review_id = str(uuid7())
+
+    p._mark_review_failed(review_id, "Cleanse failed: RuntimeError: cleanse boom")
+
+    assert record.processing_status == ProcessingStatusType.FAILED
+    assert record.error_message == "Cleanse failed: RuntimeError: cleanse boom"
+    assert record.retry_count == 3
+    mock_session.commit.assert_called_once()
+    mock_session.close.assert_called_once()

--- a/tests/test_crawler_consistency.py
+++ b/tests/test_crawler_consistency.py
@@ -1,450 +1,114 @@
-"""
-Unit tests for Crawler Distributed Consistency
+"""Crawler consistency tests for the Batch DLQ architecture.
 
-Tests NAS-first dual-write pattern and consistency guarantees.
-
-Key test areas:
-1. NAS-first write sequence (Parquet before DB)
-2. Ghost Records prevention (no DB without Parquet)
-3. Idempotency (duplicate prevention via platform_review_id)
-4. Retry mechanism (failed review tracking and retry)
+The crawler writes one daily Bronze parquet batch to MinIO and registers that
+batch in ingestion_batch as PENDING. ReviewMasterIndex rows are created later by
+the load stage, so these tests focus on batch registration and cleanup behavior.
 """
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
-from unittest.mock import patch, MagicMock, call
-from datetime import datetime, timezone
-from uuid6 import uuid7
-
-from src.crawlers.appstore_crawler import (
-    AppStoreCrawler,
-    ParquetWriteError,
-    DBCommitError
-)
-from src.models.apps import App
-from src.models.review_master_index import ReviewMasterIndex
-from src.models.enums import PlatformType, ProcessingStatusType
-
-
-class TestNASFirstWriteSequence:
-    """Test NAS-first write sequence guarantees."""
-
-    @pytest.mark.requires_db
-    def test_parquet_write_before_db_commit(
-        self,
-        test_db_session,
-        temp_bronze_dir,
-        sample_appstore_reviews
-    ):
-        """Test that Parquet write happens before DB commit.
-
-        Verification:
-        1. Mock Parquet writer and DB session
-        2. Call save_to_parquet_and_database()
-        3. Verify Parquet write called before DB commit using call order
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.enable_parquet = True
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-
-            from src.utils.parquet_writer import ParquetWriter
-            crawler.parquet_writer = ParquetWriter(
-                base_path=str(temp_bronze_dir),
-                partition_by='year_month'
-            )
-
-            # Spy on both operations
-            original_write = crawler.parquet_writer.write_batch
-            original_commit = test_db_session.commit
-
-            call_order = []
-
-            def tracked_write(records, partition_date=None):
-                call_order.append('parquet_write')
-                return original_write(records, partition_date)
-
-            def tracked_commit():
-                call_order.append('db_commit')
-                return original_commit()
-
-            crawler.parquet_writer.write_batch = tracked_write
-            test_db_session.commit = tracked_commit
-
-            # Execute
-            crawler.save_to_parquet_and_database('123456789', sample_appstore_reviews)
-
-            # Verify call order: Parquet BEFORE DB
-            assert 'parquet_write' in call_order
-            assert 'db_commit' in call_order
-
-            parquet_index = call_order.index('parquet_write')
-            db_index = call_order.index('db_commit')
-
-            assert parquet_index < db_index, \
-                f"Parquet write must happen before DB commit. Order: {call_order}"
-
-    @pytest.mark.requires_db
-    def test_db_commit_only_if_parquet_success(
-        self,
-        test_db_session,
-        temp_bronze_dir,
-        sample_appstore_reviews
-    ):
-        """Test DB commit only proceeds if Parquet write succeeds.
-
-        Verification:
-        1. Mock Parquet write success → verify DB commit is called
-        2. Mock Parquet write failure → verify DB commit is NOT called
-        3. Verify session.rollback() called on Parquet failure
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.enable_parquet = True
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-
-            from src.utils.parquet_writer import ParquetWriter
-            crawler.parquet_writer = ParquetWriter(
-                base_path=str(temp_bronze_dir),
-                partition_by='year_month'
-            )
-
-            # Scenario 1: Parquet SUCCESS → DB commit called
-            commit_spy = MagicMock(side_effect=test_db_session.commit)
-            test_db_session.commit = commit_spy
-
-            crawler.save_to_parquet_and_database('123456789', sample_appstore_reviews)
-
-            assert commit_spy.called, "DB commit should be called after Parquet success"
-
-            # Scenario 2: Parquet FAILURE → DB commit NOT called
-            test_db_session.commit.reset_mock()
-            rollback_spy = MagicMock(side_effect=test_db_session.rollback)
-            test_db_session.rollback = rollback_spy
-
-            with patch.object(
-                crawler.parquet_writer,
-                'write_batch',
-                side_effect=Exception("Parquet failed")
-            ):
-                try:
-                    crawler.save_to_parquet_and_database('999999999', sample_appstore_reviews)
-                except ParquetWriteError:
-                    pass  # Expected
-
-            assert not commit_spy.called, "DB commit should NOT be called after Parquet failure"
-            assert rollback_spy.called, "session.rollback() should be called"
-
-
-class TestGhostRecordsPrevention:
-    """Test prevention of Ghost Records (DB without Parquet)."""
-
-    @pytest.mark.requires_db
-    def test_no_db_commit_on_parquet_failure(
-        self,
-        test_db_session,
-        temp_bronze_dir,
-        sample_appstore_reviews
-    ):
-        """Test no DB commit if Parquet write fails.
-
-        Verification:
-        1. Mock Parquet write to raise ParquetWriteError
-        2. Verify DB session.rollback() is called
-        3. Verify no ReviewMasterIndex records created with status=RAW
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.enable_parquet = True
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-
-            from src.utils.parquet_writer import ParquetWriter
-            crawler.parquet_writer = ParquetWriter(
-                base_path=str(temp_bronze_dir),
-                partition_by='year_month'
-            )
-
-            rollback_spy = MagicMock(side_effect=test_db_session.rollback)
-            test_db_session.rollback = rollback_spy
-
-            # Mock Parquet to fail
-            with patch.object(
-                crawler.parquet_writer,
-                'write_batch',
-                side_effect=Exception("Disk full")
-            ):
-                with pytest.raises(ParquetWriteError):
-                    crawler.save_to_parquet_and_database('123456789', sample_appstore_reviews)
-
-            # Verify rollback called
-            assert rollback_spy.called, "session.rollback() should be called"
-
-            # Verify no RAW records
-            raw_count = test_db_session.query(ReviewMasterIndex).filter_by(
-                processing_status=ProcessingStatusType.RAW
-            ).count()
-
-            assert raw_count == 0, "No RAW records should exist after Parquet failure"
-
-    @pytest.mark.requires_db
-    def test_db_rollback_on_parquet_error(
-        self,
-        test_db_session,
-        temp_bronze_dir,
-        sample_appstore_reviews
-    ):
-        """Test DB rollback when Parquet write raises error.
-
-        Verification:
-        1. Mock Parquet writer to raise generic Exception
-        2. Verify session.rollback() called
-        3. Verify ParquetWriteError re-raised
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.enable_parquet = True
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-
-            from src.utils.parquet_writer import ParquetWriter
-            crawler.parquet_writer = ParquetWriter(
-                base_path=str(temp_bronze_dir),
-                partition_by='year_month'
-            )
-
-            rollback_spy = MagicMock(side_effect=test_db_session.rollback)
-            test_db_session.rollback = rollback_spy
-
-            with patch.object(
-                crawler.parquet_writer,
-                'write_batch',
-                side_effect=PermissionError("Access denied")
-            ):
-                with pytest.raises(ParquetWriteError) as exc_info:
-                    crawler.save_to_parquet_and_database('123456789', sample_appstore_reviews)
-
-                assert "Access denied" in str(exc_info.value)
-
-            assert rollback_spy.called, "session.rollback() should be called"
-
-
-class TestIdempotency:
-    """Test idempotency guarantees."""
-
-    @pytest.mark.requires_db
-    def test_duplicate_platform_review_id_skipped(
-        self,
-        test_db_session,
-        temp_bronze_dir,
-        sample_appstore_reviews
-    ):
-        """Test duplicate reviews are skipped via platform_review_id.
-
-        Verification:
-        1. Insert review with platform_review_id='test_123'
-        2. Call save_to_parquet_and_database() with same platform_review_id
-        3. Verify no new ReviewMasterIndex record created
-        4. Verify Parquet not written for duplicate
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.enable_parquet = True
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-
-            from src.utils.parquet_writer import ParquetWriter
-            crawler.parquet_writer = ParquetWriter(
-                base_path=str(temp_bronze_dir),
-                partition_by='year_month'
-            )
-
-            app_id = '123456789'
-
-            # First write
-            count1 = crawler.save_to_parquet_and_database(app_id, sample_appstore_reviews)
-            assert count1 == len(sample_appstore_reviews)
-
-            initial_count = test_db_session.query(ReviewMasterIndex).count()
-
-            # Second write (duplicates)
-            count2 = crawler.save_to_parquet_and_database(app_id, sample_appstore_reviews)
-
-            assert count2 == 0, "Duplicates should return 0"
-
-            final_count = test_db_session.query(ReviewMasterIndex).count()
-            assert final_count == initial_count, "No new records should be created"
-
-    @pytest.mark.requires_db
-    def test_partial_duplicate_handling(
-        self,
-        test_db_session,
-        temp_bronze_dir
-    ):
-        """Test handling of partially duplicated review batches.
-
-        Verification:
-        1. Insert 5 existing reviews
-        2. Call save with batch of 10 reviews (5 old + 5 new)
-        3. Verify only 5 new records added
-        4. Verify only 5 Parquet records written
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.enable_parquet = True
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-
-            from src.utils.parquet_writer import ParquetWriter
-            crawler.parquet_writer = ParquetWriter(
-                base_path=str(temp_bronze_dir),
-                partition_by='year_month'
-            )
-
-            app_id = '123456789'
-
-            # Create 5 old reviews
-            old_reviews = [
-                {
-                    'id': {'label': f'old_{i}'},
-                    'author': {'name': {'label': f'User{i}'}},
-                    'im:name': {'label': 'Test App'},
-                    'content': {'label': f'Old review {i}'},
-                    'im:rating': {'label': '5'},
-                    'updated': {'label': '2026-02-04T12:00:00Z'},
-                }
-                for i in range(5)
-            ]
-
-            # First write
-            count1 = crawler.save_to_parquet_and_database(app_id, old_reviews)
-            assert count1 == 5
-
-            # Create mixed batch (5 old + 5 new)
-            new_reviews = [
-                {
-                    'id': {'label': f'new_{i}'},
-                    'author': {'name': {'label': f'NewUser{i}'}},
-                    'im:name': {'label': 'Test App'},
-                    'content': {'label': f'New review {i}'},
-                    'im:rating': {'label': '4'},
-                    'updated': {'label': '2026-02-05T12:00:00Z'},
-                }
-                for i in range(5)
-            ]
-
-            mixed_batch = old_reviews + new_reviews
-
-            # Second write
-            count2 = crawler.save_to_parquet_and_database(app_id, mixed_batch)
-
-            assert count2 == 5, "Only 5 new reviews should be added"
-
-            total = test_db_session.query(ReviewMasterIndex).count()
-            assert total == 10, "Total should be 10 (5 old + 5 new)"
-
-
-class TestRetryMechanism:
-    """Test retry mechanism for failed writes."""
-
-    @pytest.mark.requires_db
-    def test_retry_failed_reviews(self, test_db_session, db_with_failed_reviews, sample_appstore_reviews):
-        """Test retry_failed_reviews() method with full re-crawl.
-
-        Verification:
-        1. Insert ReviewMasterIndex with processing_status=FAILED
-        2. Mock API calls to return sample reviews
-        3. Call retry_failed_reviews()
-        4. Verify failed reviews are re-processed successfully
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-            crawler.enable_parquet = False  # Disable Parquet for simplicity
-
-            # Mock the API call to return sample reviews
-            crawler.get_app_store_reviews_and_appname = MagicMock(
-                return_value=('Test App', sample_appstore_reviews)
-            )
-
-            # Mock save_to_parquet_and_database to succeed
-            crawler.save_to_parquet_and_database = MagicMock(return_value=len(sample_appstore_reviews))
-
-            # db_with_failed_reviews has 3 reviews from app '999999999':
-            # - retry_count=0
-            # - retry_count=1
-            # - retry_count=3 (max reached)
-
-            retried_count = crawler.retry_failed_reviews(max_retries=3)
-
-            # Should retry 1 app (that has 2 retryable reviews)
-            assert retried_count == 1, f"Expected 1 app retried, got {retried_count}"
-
-            # Verify API was called to re-crawl
-            crawler.get_app_store_reviews_and_appname.assert_called_once_with('999999999')
-
-            # Verify save method was called
-            crawler.save_to_parquet_and_database.assert_called_once()
-
-    @pytest.mark.requires_db
-    def test_max_retries_reached(self, test_db_session, db_with_failed_reviews, sample_appstore_reviews):
-        """Test DLQ behavior when max retries reached.
-
-        Verification:
-        1. Insert FAILED review with retry_count=3
-        2. Call retry_failed_reviews(max_retries=3)
-        3. Verify review NOT selected for retry
-        4. Verify review remains in FAILED state
-        """
-        with patch.object(AppStoreCrawler, '__init__', lambda self, config_path=None: None):
-            crawler = AppStoreCrawler()
-            crawler.logger = MagicMock()
-            crawler.config = {}
-            crawler.db_connector = MagicMock()
-            crawler.db_connector.get_session.return_value = test_db_session
-            crawler.enable_parquet = False  # Disable Parquet for simplicity
-
-            # Mock API call to return sample reviews (for the 2 retryable reviews)
-            crawler.get_app_store_reviews_and_appname = MagicMock(
-                return_value=('Test App', sample_appstore_reviews)
-            )
-
-            # Mock save method
-            crawler.save_to_parquet_and_database = MagicMock(return_value=len(sample_appstore_reviews))
-
-            # Execute retry
-            retried_count = crawler.retry_failed_reviews(max_retries=3)
-
-            # Should retry 1 app (that has 2 reviews with retry_count < 3)
-            # The review with retry_count=3 should be excluded from query
-            assert retried_count == 1, f"Should retry 1 app, got {retried_count}"
-
-            # Verify review with retry_count=3 still exists and unchanged
-            review_max = test_db_session.query(ReviewMasterIndex).filter_by(
-                platform_review_id='failed_review_3'
-            ).first()
-
-            assert review_max is not None, "Max retry review should still exist"
-            assert review_max.retry_count == 3, \
-                "Max retry review should not be incremented"
-            assert review_max.processing_status == ProcessingStatusType.FAILED
-
-
-if __name__ == '__main__':
-    pytest.main([__file__, '-v'])
+
+from src.crawlers.appstore_crawler import AppStoreCrawler, ParquetWriteError
+from src.models.enums import IngestionBatchStatusType, PlatformType
+from src.models.ingestion_batch import IngestionBatch
+
+
+def _make_crawler(session):
+    """Create an AppStoreCrawler test double with only save_daily_batch dependencies."""
+    with patch.object(AppStoreCrawler, "__init__", lambda self, config_path=None: None):
+        crawler = AppStoreCrawler()
+    crawler.logger = MagicMock()
+    crawler.enable_parquet = True
+    crawler.max_retries = 3
+    crawler._minio = MagicMock()
+    crawler.db_connector = MagicMock()
+    crawler.db_connector.get_session.return_value = session
+    return crawler
+
+
+def _records(count=2):
+    """Return schema-like records accepted by BaseCrawler.save_daily_batch."""
+    return [
+        SimpleNamespace(
+            model_dump=lambda i=i: {
+                "review_id": f"019db8c0-a18{i}-7000-8000-00000000000{i}",
+                "app_id": "019db8c0-a180-7000-8000-000000000001",
+                "platform_type": "APPSTORE",
+                "platform_review_id": f"review_{i}",
+                "reviewer_name": f"User {i}",
+                "review_text": f"Review text {i}",
+                "rating": 5,
+                "reviewed_at": datetime(2026, 3, 4, 12, i, tzinfo=timezone.utc),
+                "is_reply": False,
+                "reply_comment": None,
+            }
+        )
+        for i in range(count)
+    ]
+
+
+@pytest.mark.requires_db
+def test_save_daily_batch_uploads_parquet_before_registering_pending_batch(test_db_session):
+    """Successful crawl output creates a MinIO parquet file before PENDING batch commit."""
+    crawler = _make_crawler(test_db_session)
+    partition_date = datetime(2026, 3, 4, tzinfo=timezone.utc)
+
+    batch_id, count, s3_key = crawler.save_daily_batch(
+        _records(2),
+        PlatformType.APPSTORE,
+        partition_date=partition_date,
+    )
+
+    assert count == 2
+    assert s3_key.startswith("bronze/app_reviews/year=2026/month=03/day=04/appstore_")
+    crawler._minio.put_parquet.assert_called_once()
+    assert crawler._minio.put_parquet.call_args.args[0] == s3_key
+
+    batch = test_db_session.query(IngestionBatch).filter_by(batch_id=batch_id).one()
+    assert batch.source_type == PlatformType.APPSTORE
+    assert batch.platform_app_id == "daily_batch"
+    assert batch.storage_path == s3_key
+    assert batch.file_format == "parquet"
+    assert batch.record_count == 2
+    assert batch.status == IngestionBatchStatusType.PENDING
+    assert batch.retry_count == 0
+    assert batch.max_retries == 3
+
+
+def test_save_daily_batch_does_not_open_db_session_when_minio_upload_fails():
+    """MinIO failure prevents ghost ingestion_batch records."""
+    crawler = _make_crawler(MagicMock())
+    crawler._minio.put_parquet.side_effect = RuntimeError("upload down")
+
+    with pytest.raises(ParquetWriteError, match="upload down"):
+        crawler.save_daily_batch(_records(1), PlatformType.APPSTORE)
+
+    crawler.db_connector.get_session.assert_not_called()
+
+
+def test_save_daily_batch_cleans_up_minio_object_when_batch_commit_fails():
+    """DB registration failure rolls back and deletes the already uploaded parquet object."""
+    session = MagicMock()
+    session.commit.side_effect = RuntimeError("commit down")
+    crawler = _make_crawler(session)
+
+    with pytest.raises(RuntimeError, match="commit down"):
+        crawler.save_daily_batch(_records(1), PlatformType.APPSTORE)
+
+    s3_key = crawler._minio.put_parquet.call_args.args[0]
+    session.rollback.assert_called_once()
+    crawler._minio.delete_object.assert_called_once_with(s3_key)
+    session.close.assert_called_once()
+
+
+def test_save_daily_batch_returns_empty_result_without_side_effects_for_empty_records():
+    """Empty crawl output skips MinIO and DB work."""
+    crawler = _make_crawler(MagicMock())
+
+    assert crawler.save_daily_batch([], PlatformType.APPSTORE) == (None, 0, None)
+
+    crawler._minio.put_parquet.assert_not_called()
+    crawler.db_connector.get_session.assert_not_called()

--- a/tests/test_crawler_consistency.py
+++ b/tests/test_crawler_consistency.py
@@ -11,7 +11,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from src.crawlers.appstore_crawler import AppStoreCrawler, ParquetWriteError
+from src.crawlers.appstore_crawler import AppStoreCrawler
+from src.crawlers.exceptions import ParquetWriteError
 from src.models.enums import IngestionBatchStatusType, PlatformType
 from src.models.ingestion_batch import IngestionBatch
 

--- a/tests/test_database_schema.py
+++ b/tests/test_database_schema.py
@@ -1,7 +1,7 @@
-"""Test SQL Schema Validation (sql/schema_v2.sql)
+"""Test SQL Schema Validation (sql/schema_v4.sql)
 
-This module validates that sql/schema_v2.sql creates the correct database schema:
-- Extensions (uuid-ossp, vector, ltree)
+This module validates that sql/schema_v4.sql creates the correct database schema:
+- Extensions (vector)
 - ENUM types (platform_type, app_type, etc.)
 - Tables (apps, review_master_index, etc.)
 - Constraints (PKs, FKs, unique constraints)
@@ -21,8 +21,8 @@ from sqlalchemy import inspect, text
 # ========================================
 
 def test_schema_file_exists():
-    """Test that schema_v2.sql file exists and is readable."""
-    schema_file = Path(__file__).parent.parent / "sql" / "schema_v2.sql"
+    """Test that schema_v4.sql file exists and is readable."""
+    schema_file = Path(__file__).parent.parent / "sql" / "schema_v4.sql"
     assert schema_file.exists(), f"Schema file not found: {schema_file}"
     assert schema_file.is_file(), f"Schema path is not a file: {schema_file}"
 
@@ -34,7 +34,7 @@ def test_schema_file_exists():
 
 @pytest.mark.requires_db
 def test_schema_sql_syntax_valid(test_db_engine, test_db_schema):
-    """Test that schema_v2.sql executes without syntax errors.
+    """Test that schema_v4.sql executes without syntax errors.
 
     This test is implicitly validated by test_db_schema fixture.
     If schema has syntax errors, fixture initialization will fail.
@@ -133,6 +133,7 @@ def test_all_tables_created(test_db_session):
         'apps',
         'app_service',
         'app_metadata',
+        'ingestion_batch',
         'review_master_index',
         'app_reviews',
         'reviews_preprocessed',
@@ -140,6 +141,10 @@ def test_all_tables_created(test_db_session):
         'review_aspects',
         'review_action_analysis',
         'reviews_assigned',
+        'fact_service_review_daily',
+        'fact_service_aspect_daily',
+        'fact_category_radar_scores',
+        'srv_daily_review_list',
         'organizations',
         'profanities',
         'synonyms',
@@ -279,12 +284,11 @@ def test_indexes_exist(test_db_session):
 
     index_names = {row[0] for row in result}
 
-    # Critical indexes for Phase 3 NAS-first architecture
+    # Critical indexes for current schema v4 architecture
     expected_indexes = {
         'idx_review_master_index_processing_status',
         'idx_review_master_index_app_id',
-        'idx_review_master_index_failed',  # WHERE processing_status = 'FAILED'
-        'idx_review_master_index_retry',   # WHERE retry_count < 3
+        'idx_review_master_index_storage_path',
     }
 
     missing_indexes = expected_indexes - index_names
@@ -295,6 +299,28 @@ def test_indexes_exist(test_db_session):
 
     assert len(critical_missing) == 0, \
         f"Critical indexes missing: {critical_missing}"
+
+
+@pytest.mark.requires_db
+def test_ingestion_batch_indexes_exist(test_db_session):
+    """Test that batch-level DLQ indexes exist."""
+    result = test_db_session.execute(text(
+        """
+        SELECT indexname
+        FROM pg_indexes
+        WHERE tablename = 'ingestion_batch'
+        """
+    ))
+
+    index_names = {row[0] for row in result}
+    expected_indexes = {
+        'idx_ingestion_batch_status',
+        'idx_ingestion_batch_pending',
+        'idx_ingestion_batch_source_app',
+    }
+
+    assert expected_indexes.issubset(index_names), \
+        f"Missing ingestion_batch indexes: {expected_indexes - index_names}"
 
 
 @pytest.mark.requires_db

--- a/tests/test_database_schema.py
+++ b/tests/test_database_schema.py
@@ -293,12 +293,8 @@ def test_indexes_exist(test_db_session):
 
     missing_indexes = expected_indexes - index_names
 
-    # Allow some flexibility (partial index names might differ)
-    critical_missing = [idx for idx in missing_indexes
-                        if 'processing_status' in idx or 'app_id' in idx]
-
-    assert len(critical_missing) == 0, \
-        f"Critical indexes missing: {critical_missing}"
+    assert not missing_indexes, \
+        f"Expected indexes missing: {missing_indexes}"
 
 
 @pytest.mark.requires_db

--- a/tests/test_enums.py
+++ b/tests/test_enums.py
@@ -71,7 +71,7 @@ def test_model_uses_central_enums():
     # This tests that ENUMs are properly referenced in model definitions
 
     # App model uses PlatformType
-    assert hasattr(App, 'platform')
+    assert hasattr(App, 'platform_type')
 
     # ReviewMasterIndex uses PlatformType and ProcessingStatusType
     assert hasattr(ReviewMasterIndex, 'platform_type')

--- a/tests/test_pipeline_failures.py
+++ b/tests/test_pipeline_failures.py
@@ -29,6 +29,8 @@ def test_fetch_review_dead_letters_queries_failed_max_retry_reviews():
     assert results == [sentinel.review]
     session.query.assert_called_once_with(ReviewMasterIndex)
     assert query.filter.call_count == 2
+    order_clause = str(query.order_by.call_args.args[0])
+    assert "NULLS LAST" in order_clause
     query.limit.assert_called_once_with(25)
     assert "processing_status = 'FAILED'" in REVIEW_DEAD_LETTER_SQL
     assert "retry_count >= 3" in REVIEW_DEAD_LETTER_SQL

--- a/tests/test_pipeline_failures.py
+++ b/tests/test_pipeline_failures.py
@@ -46,3 +46,21 @@ def test_fetch_batch_dead_letters_queries_dead_letter_batches():
     query.filter.assert_called_once()
     query.limit.assert_called_once_with(10)
     assert "status = 'DEAD_LETTER'" in BATCH_DEAD_LETTER_SQL
+
+
+def test_fetch_review_dead_letters_normalizes_invalid_limit_to_default():
+    session, query = _session_with_query_result([sentinel.review])
+
+    results = fetch_review_dead_letters(session, limit=0)
+
+    assert results == [sentinel.review]
+    query.limit.assert_called_once_with(100)
+
+
+def test_fetch_batch_dead_letters_normalizes_invalid_limit_to_default():
+    session, query = _session_with_query_result([sentinel.batch])
+
+    results = fetch_batch_dead_letters(session, limit=None)
+
+    assert results == [sentinel.batch]
+    query.limit.assert_called_once_with(100)

--- a/tests/test_pipeline_failures.py
+++ b/tests/test_pipeline_failures.py
@@ -1,0 +1,46 @@
+from unittest.mock import MagicMock, sentinel
+
+from src.models.ingestion_batch import IngestionBatch
+from src.models.review_master_index import ReviewMasterIndex
+from src.pipeline.failures import (
+    BATCH_DEAD_LETTER_SQL,
+    REVIEW_DEAD_LETTER_SQL,
+    fetch_batch_dead_letters,
+    fetch_review_dead_letters,
+)
+
+
+def _session_with_query_result(result):
+    session = MagicMock()
+    query = MagicMock()
+    query.filter.return_value = query
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.all.return_value = result
+    session.query.return_value = query
+    return session, query
+
+
+def test_fetch_review_dead_letters_queries_failed_max_retry_reviews():
+    session, query = _session_with_query_result([sentinel.review])
+
+    results = fetch_review_dead_letters(session, limit=25)
+
+    assert results == [sentinel.review]
+    session.query.assert_called_once_with(ReviewMasterIndex)
+    assert query.filter.call_count == 2
+    query.limit.assert_called_once_with(25)
+    assert "processing_status = 'FAILED'" in REVIEW_DEAD_LETTER_SQL
+    assert "retry_count >= 3" in REVIEW_DEAD_LETTER_SQL
+
+
+def test_fetch_batch_dead_letters_queries_dead_letter_batches():
+    session, query = _session_with_query_result([sentinel.batch])
+
+    results = fetch_batch_dead_letters(session, limit=10)
+
+    assert results == [sentinel.batch]
+    session.query.assert_called_once_with(IngestionBatch)
+    query.filter.assert_called_once()
+    query.limit.assert_called_once_with(10)
+    assert "status = 'DEAD_LETTER'" in BATCH_DEAD_LETTER_SQL


### PR DESCRIPTION
## Summary

- Re-aligned #7 around existing schema v4 failure sources instead of adding a generic `pipeline_step_failures` table.
- Records cleanse row-level failures in `review_master_index` with `FAILED`, `error_message`, and incremented `retry_count`, while continuing other rows.
- Adds dead-letter query helpers for batch-level `ingestion_batch.DEAD_LETTER` and review-level `review_master_index FAILED + retry_count >= 3`.
- Documents the pipeline failure policy and fixes schema v2/v4 test/doc drift.

## Why

`review_master_index` already exists as the review-level orchestration hub, and `ingestion_batch` already owns batch-level load failures. Adding a generic step failure table in this PR would duplicate existing state for the cases that #7 can solve today. Job/date-level aggregate failure history remains a follow-up concern if DB-backed Airflow/job failure tracking is required.

## Validation

- [x] `uv test` attempted, but local `uv` does not support a `test` subcommand.
- [x] `PYTHONPATH=. uv run pytest tests/test_cleanse.py tests/test_pipeline_failures.py tests/test_pipeline_steps.py tests/test_database_schema.py::test_schema_file_exists tests/test_gold_orchestrator.py`
  - 68 passed, 1 warning
- [x] `PYTHONPATH=. uv run pytest tests/test_database_schema.py tests/test_batch_loader.py tests/test_gold_orchestrator.py`
  - `test_gold_orchestrator.py` passed
  - DB-dependent schema/batch-loader tests could not run because local PostgreSQL at `localhost:5433` refused connections
- [ ] `PYTHONPATH=. uv run pytest`
  - blocked during collection by existing `tests/test_crawler_consistency.py` import error: `DBCommitError` is not exported from `src.crawlers.appstore_crawler`

Closes #7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a pipeline failure policy for schema v4 describing authoritative failure sources, dead-letter selection queries, and cleanse exception semantics.

* **New Features**
  * Retrieval of batch and review dead letters.
  * Per-row cleansing that marks individual reviews as failed and excludes them from downstream outputs.

* **Updates**
  * Project schema references migrated to v4; empty review text is treated as skipped; cleanse can recover prior failed rows.

* **Tests**
  * Expanded coverage for failure retrieval, row-level cleanse error handling, schema validation, and test infra.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->