### PR TITLE
[codex] Add local DB bootstrap command

### DIFF
--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -51,14 +51,14 @@ This command is intentionally local-development oriented:
 ```bash
 PYTHONPATH=. uv run python scripts/crawl_reviews.py
 PYTHONPATH=. uv run python scripts/load_reviews.py
-PYTHONPATH=. uv run python scripts/cleanse_reviews.py --date 2026-04-26
+PYTHONPATH=. uv run python scripts/cleanse_reviews.py --date YYYY-MM-DD
 ```
 
 Notes:
 
 - `crawl_reviews.py` uploads Bronze Parquet batches to MinIO and registers `ingestion_batch` rows.
 - `load_reviews.py` consumes those pending batches into PostgreSQL.
-- `cleanse_reviews.py --date ...` must match the Bronze partition date you actually crawled.
+- Replace `YYYY-MM-DD` with the Bronze partition date you actually crawled, or use a shell expression such as `$(date -I)` for today's partition.
 - Gold analyze/aggregate steps require a real `OPENAI_API_KEY`.
 
 ## Verify results

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -1,6 +1,6 @@
 # Local Development Stack
 
-This project can run its local infrastructure with Docker Compose using PostgreSQL and MinIO only.
+This project runs its local infrastructure with Docker Compose using PostgreSQL and MinIO only. Python entrypoints run from the host with `uv run ...`.
 
 ## Start the stack
 
@@ -18,13 +18,57 @@ The `minio-init` one-shot service creates the `reai-data` bucket automatically.
 
 ## Configure the app
 
-Create a local env file from `.env.local.example` and load it before running scripts from the host environment.
+Create a local env file from `.env.local.example`.
+
+```bash
+cp .env.local.example .env
+uv sync
+```
 
 Key values in `.env.local.example`:
 
 - `DATABASE_URL=postgresql+psycopg2://reai:reai@localhost:5432/reai`
 - `MINIO_ENDPOINT=localhost:9000`
 - `MINIO_BUCKET=reai-data`
+
+## Bootstrap the database
+
+Use the bootstrap command instead of manually applying `schema_v4.sql`, `app_service_data.sql`, `apps_data.sql`, and `app_metadata_data.sql`.
+
+```bash
+PYTHONPATH=. uv run python scripts/bootstrap_db.py
+```
+
+This command is intentionally local-development oriented:
+
+- it resets the `public` schema
+- reapplies `schema_v4.sql`
+- loads required reference seed data from `app_service_data.sql`, `apps_data.sql`, and `app_metadata_data.sql`
+- verifies the expected seed counts before returning success
+
+## Run the minimum ETL flow
+
+```bash
+PYTHONPATH=. uv run python scripts/crawl_reviews.py
+PYTHONPATH=. uv run python scripts/load_reviews.py
+PYTHONPATH=. uv run python scripts/cleanse_reviews.py --date 2026-04-26
+```
+
+Notes:
+
+- `crawl_reviews.py` uploads Bronze Parquet batches to MinIO and registers `ingestion_batch` rows.
+- `load_reviews.py` consumes those pending batches into PostgreSQL.
+- `cleanse_reviews.py --date ...` must match the Bronze partition date you actually crawled.
+- Gold analyze/aggregate steps require a real `OPENAI_API_KEY`.
+
+## Verify results
+
+- DataGrip / PostgreSQL:
+  - `select count(*) from ingestion_batch;`
+  - `select processing_status, count(*) from review_master_index group by 1 order by 1;`
+- MinIO Console:
+  - Bronze objects under `bronze/app_reviews/...`
+  - Silver objects under `silver/reviews/...`
 
 ## Stop the stack
 

--- a/scripts/bootstrap_db.py
+++ b/scripts/bootstrap_db.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""Bootstrap the local PostgreSQL database for development."""
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from src.bootstrap_db import main  # noqa: E402
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/bootstrap_db.py
+++ b/src/bootstrap_db.py
@@ -20,7 +20,7 @@ SQL_FILE_ORDER = (
     "app_metadata_data.sql",
 )
 
-LOCAL_DB_HOSTS = {"localhost", "127.0.0.1"}
+LOCAL_DB_HOSTS = {"localhost", "127.0.0.1", "::1"}
 
 
 @dataclass(frozen=True)
@@ -171,4 +171,3 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     return 0
-

--- a/src/bootstrap_db.py
+++ b/src/bootstrap_db.py
@@ -1,0 +1,174 @@
+"""Local database bootstrap helpers for reproducible development setup."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import URL, Engine, make_url
+
+
+SQL_FILE_ORDER = (
+    "schema_v4.sql",
+    "app_service_data.sql",
+    "apps_data.sql",
+    "app_metadata_data.sql",
+)
+
+LOCAL_DB_HOSTS = {"localhost", "127.0.0.1"}
+
+
+@dataclass(frozen=True)
+class BootstrapVerification:
+    name: str
+    query: str
+    expected_count: int
+
+
+class BootstrapError(RuntimeError):
+    """Raised when local DB bootstrap cannot be completed safely."""
+
+
+def get_project_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def get_bootstrap_sql_paths(root: Path) -> list[Path]:
+    sql_dir = root / "sql"
+    return [sql_dir / filename for filename in SQL_FILE_ORDER]
+
+
+def build_verification_queries() -> list[BootstrapVerification]:
+    return [
+        BootstrapVerification("app_service", "SELECT COUNT(*) FROM app_service", 39),
+        BootstrapVerification("apps", "SELECT COUNT(*) FROM apps", 63),
+        BootstrapVerification(
+            "app_metadata_active",
+            "SELECT COUNT(*) FROM app_metadata WHERE is_active = TRUE",
+            63,
+        ),
+    ]
+
+
+def is_local_database_url(url: URL) -> bool:
+    return url.host in LOCAL_DB_HOSTS
+
+
+def load_database_url(root: Path, explicit_url: str | None = None) -> str:
+    env_path = root / ".env"
+    if env_path.exists():
+        load_dotenv(env_path)
+
+    database_url = explicit_url or os.getenv("DATABASE_URL")
+    if not database_url:
+        raise BootstrapError(
+            "DATABASE_URL is required. Create .env from .env.local.example before bootstrapping."
+        )
+    return database_url
+
+
+def validate_bootstrap_target(database_url: str) -> URL:
+    url = make_url(database_url)
+    if not is_local_database_url(url):
+        raise BootstrapError(
+            f"Refusing to bootstrap non-local database host {url.host!r}. "
+            "Use a localhost DATABASE_URL for local development."
+        )
+    return url
+
+
+def ensure_sql_files_exist(sql_paths: Iterable[Path]) -> None:
+    missing_files = [str(path) for path in sql_paths if not path.exists()]
+    if missing_files:
+        raise BootstrapError(f"Missing bootstrap SQL files: {', '.join(missing_files)}")
+
+
+def reset_public_schema(engine: Engine) -> None:
+    raw_conn = engine.raw_connection()
+    try:
+        cursor = raw_conn.cursor()
+        cursor.execute("DROP SCHEMA IF EXISTS public CASCADE;")
+        cursor.execute("CREATE SCHEMA public;")
+        raw_conn.commit()
+    finally:
+        raw_conn.close()
+
+
+def execute_sql_file(engine: Engine, sql_path: Path) -> None:
+    sql_text = sql_path.read_text()
+    raw_conn = engine.raw_connection()
+    try:
+        cursor = raw_conn.cursor()
+        cursor.execute(sql_text)
+        raw_conn.commit()
+    finally:
+        raw_conn.close()
+
+
+def run_verifications(engine: Engine, verifications: Iterable[BootstrapVerification]) -> None:
+    with engine.connect() as conn:
+        for verification in verifications:
+            actual_count = conn.execute(text(verification.query)).scalar_one()
+            if actual_count != verification.expected_count:
+                raise BootstrapError(
+                    f"Verification failed for {verification.name}: "
+                    f"expected {verification.expected_count}, got {actual_count}"
+                )
+
+
+def bootstrap_database(database_url: str | None = None, *, stdout=print) -> None:
+    root = get_project_root()
+    resolved_url = load_database_url(root, database_url)
+    validate_bootstrap_target(resolved_url)
+
+    sql_paths = get_bootstrap_sql_paths(root)
+    ensure_sql_files_exist(sql_paths)
+
+    stdout("Bootstrapping local database")
+    stdout(f"- target: {make_url(resolved_url).render_as_string(hide_password=True)}")
+
+    engine = create_engine(resolved_url)
+    try:
+        stdout("- resetting public schema")
+        reset_public_schema(engine)
+
+        for sql_path in sql_paths:
+            stdout(f"- applying {sql_path.name}")
+            execute_sql_file(engine, sql_path)
+
+        stdout("- running verification queries")
+        run_verifications(engine, build_verification_queries())
+        stdout("Bootstrap complete")
+    finally:
+        engine.dispose()
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Reset the local PostgreSQL public schema and load required REAI seed data."
+    )
+    parser.add_argument(
+        "--database-url",
+        default=None,
+        help="Override DATABASE_URL. Intended for local localhost targets only.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        bootstrap_database(args.database_url)
+    except BootstrapError as exc:
+        print(f"Bootstrap failed: {exc}")
+        return 1
+
+    return 0
+

--- a/tests/test_bootstrap_db.py
+++ b/tests/test_bootstrap_db.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+
+import pytest
+from sqlalchemy.engine import make_url
+
+from src.bootstrap_db import (
+    BootstrapVerification,
+    build_verification_queries,
+    get_bootstrap_sql_paths,
+    is_local_database_url,
+)
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_bootstrap_sql_paths_are_in_required_order():
+    sql_paths = get_bootstrap_sql_paths(ROOT)
+
+    assert [path.name for path in sql_paths] == [
+        "schema_v4.sql",
+        "app_service_data.sql",
+        "apps_data.sql",
+        "app_metadata_data.sql",
+    ]
+
+
+def test_is_local_database_url_accepts_localhost_targets():
+    assert is_local_database_url(make_url("postgresql://reai:reai@localhost:5432/reai"))
+    assert is_local_database_url(make_url("postgresql://reai:reai@127.0.0.1:5432/reai"))
+
+
+def test_is_local_database_url_rejects_remote_targets():
+    assert not is_local_database_url(make_url("postgresql://reai:reai@db.internal:5432/reai"))
+    assert not is_local_database_url(make_url("postgresql://reai:reai@10.0.0.15:5432/reai"))
+
+
+def test_build_verification_queries_check_required_seed_counts():
+    queries = build_verification_queries()
+
+    assert queries == [
+        BootstrapVerification("app_service", "SELECT COUNT(*) FROM app_service", 39),
+        BootstrapVerification("apps", "SELECT COUNT(*) FROM apps", 63),
+        BootstrapVerification("app_metadata_active", "SELECT COUNT(*) FROM app_metadata WHERE is_active = TRUE", 63),
+    ]
+
+
+def test_bootstrap_script_exists():
+    bootstrap_script = ROOT / "scripts" / "bootstrap_db.py"
+    assert bootstrap_script.exists(), "scripts/bootstrap_db.py must exist for local bootstrap"
+
+
+def test_local_docs_reference_bootstrap_command():
+    docs_path = ROOT / "docs" / "local-development.md"
+    content = docs_path.read_text()
+
+    assert "scripts/bootstrap_db.py" in content
+    assert "app_metadata_data.sql" in content
+    assert "crawl_reviews.py" in content
+

--- a/tests/test_bootstrap_db.py
+++ b/tests/test_bootstrap_db.py
@@ -4,10 +4,12 @@ import pytest
 from sqlalchemy.engine import make_url
 
 from src.bootstrap_db import (
+    BootstrapError,
     BootstrapVerification,
     build_verification_queries,
     get_bootstrap_sql_paths,
     is_local_database_url,
+    validate_bootstrap_target,
 )
 
 
@@ -28,11 +30,23 @@ def test_bootstrap_sql_paths_are_in_required_order():
 def test_is_local_database_url_accepts_localhost_targets():
     assert is_local_database_url(make_url("postgresql://reai:reai@localhost:5432/reai"))
     assert is_local_database_url(make_url("postgresql://reai:reai@127.0.0.1:5432/reai"))
+    assert is_local_database_url(make_url("postgresql://reai:reai@[::1]:5432/reai"))
 
 
 def test_is_local_database_url_rejects_remote_targets():
     assert not is_local_database_url(make_url("postgresql://reai:reai@db.internal:5432/reai"))
     assert not is_local_database_url(make_url("postgresql://reai:reai@10.0.0.15:5432/reai"))
+
+
+def test_validate_bootstrap_target_accepts_localhost_url():
+    validated = validate_bootstrap_target("postgresql://reai:reai@localhost:5432/reai")
+
+    assert validated.host == "localhost"
+
+
+def test_validate_bootstrap_target_rejects_remote_url():
+    with pytest.raises(BootstrapError):
+        validate_bootstrap_target("postgresql://reai:reai@db.internal:5432/reai")
 
 
 def test_build_verification_queries_check_required_seed_counts():
@@ -57,4 +71,3 @@ def test_local_docs_reference_bootstrap_command():
     assert "scripts/bootstrap_db.py" in content
     assert "app_metadata_data.sql" in content
     assert "crawl_reviews.py" in content
-


### PR DESCRIPTION
## Summary
- add a local bootstrap command that resets the local public schema, applies schema and required seed SQL in order, and verifies required seed counts
- document the host-based local development flow from compose setup through bootstrap, ETL, and verification
- add focused tests for bootstrap ordering, local target guardrails, seed count checks, and docs coverage

## Validation
- PYTHONPATH=. uv run pytest tests/test_bootstrap_db.py
- PYTHONPATH=. uv run python scripts/bootstrap_db.py --help

Closes #76
Refs #72

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced automated local database bootstrapping to replace manual SQL file setup
  * Added verification checks to validate database initialization

* **Documentation**
  * Clarified local development environment configuration steps
  * Updated with detailed end-to-end ETL workflow instructions
  * Added explicit verification procedures for database setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->