### PR TITLE
[codex] Add CI validation for local DB bootstrap

### DIFF
--- a/.github/workflows/bootstrap-db.yml
+++ b/.github/workflows/bootstrap-db.yml
@@ -1,0 +1,60 @@
+name: Bootstrap DB
+
+"on":
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  bootstrap-db:
+    name: Validate local DB bootstrap
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg17
+        env:
+          POSTGRES_DB: reai
+          POSTGRES_USER: reai
+          POSTGRES_PASSWORD: reai
+          POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
+        ports:
+          - "5432:5432"
+        options: >-
+          --health-cmd "pg_isready -U reai -d reai"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 12
+
+    env:
+      DATABASE_URL: postgresql+psycopg2://reai:reai@localhost:5432/reai
+      TEST_DATABASE_URL: postgresql+psycopg2://reai:reai@localhost:5432/reai
+      PYTHONPATH: .
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Bootstrap local database
+        run: PYTHONPATH=. uv run python scripts/bootstrap_db.py --database-url postgresql+psycopg2://reai:reai@localhost:5432/reai
+
+      - name: Run focused bootstrap tests
+        run: PYTHONPATH=. uv run pytest tests/test_bootstrap_db.py tests/test_local_dev_setup.py

--- a/.github/workflows/bootstrap-db.yml
+++ b/.github/workflows/bootstrap-db.yml
@@ -17,7 +17,7 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg17
+        image: pgvector/pgvector:pg17@sha256:494dff7e67e7bc2c826b94c331364978d145ebb86fd338154138b084223b7f67
         env:
           POSTGRES_DB: reai
           POSTGRES_USER: reai
@@ -38,15 +38,15 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b
         with:
           enable-cache: true
 
@@ -57,4 +57,4 @@ jobs:
         run: PYTHONPATH=. uv run python scripts/bootstrap_db.py --database-url postgresql+psycopg2://reai:reai@localhost:5432/reai
 
       - name: Run focused bootstrap tests
-        run: PYTHONPATH=. uv run pytest tests/test_bootstrap_db.py tests/test_local_dev_setup.py
+        run: PYTHONPATH=. uv run pytest tests/test_ci_workflows.py tests/test_bootstrap_db.py tests/test_local_dev_setup.py

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -19,8 +19,12 @@ def test_ci_bootstrap_workflow_runs_against_pgvector_postgres():
     postgres = job["services"]["postgres"]
 
     assert "pull_request" in workflow["on"]
+    assert "workflow_dispatch" in workflow["on"]
     assert workflow["on"]["push"]["branches"] == ["main"]
-    assert postgres["image"] == "pgvector/pgvector:pg17"
+    assert (
+        postgres["image"]
+        == "pgvector/pgvector:pg17@sha256:494dff7e67e7bc2c826b94c331364978d145ebb86fd338154138b084223b7f67"
+    )
     assert postgres["ports"] == ["5432:5432"]
     assert postgres["env"] == {
         "POSTGRES_DB": "reai",
@@ -35,6 +39,8 @@ def test_ci_bootstrap_workflow_documents_reproducible_commands():
     workflow = load_bootstrap_workflow()
 
     job = workflow["jobs"]["bootstrap-db"]
+    checkout_step = next(step for step in job["steps"] if step["name"] == "Check out repository")
+    python_step = next(step for step in job["steps"] if step["name"] == "Set up Python")
     uv_step = next(step for step in job["steps"] if step["name"] == "Set up uv")
     run_commands = "\n".join(
         step["run"]
@@ -42,12 +48,14 @@ def test_ci_bootstrap_workflow_documents_reproducible_commands():
         if "run" in step
     )
 
-    assert uv_step["uses"] == "astral-sh/setup-uv@v8.1.0"
+    assert checkout_step["uses"] == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+    assert python_step["uses"] == "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405"
+    assert uv_step["uses"] == "astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b"
     assert (
         "PYTHONPATH=. uv run python scripts/bootstrap_db.py "
         "--database-url postgresql+psycopg2://reai:reai@localhost:5432/reai"
     ) in run_commands
     assert (
         "PYTHONPATH=. uv run pytest "
-        "tests/test_bootstrap_db.py tests/test_local_dev_setup.py"
+        "tests/test_ci_workflows.py tests/test_bootstrap_db.py tests/test_local_dev_setup.py"
     ) in run_commands

--- a/tests/test_ci_workflows.py
+++ b/tests/test_ci_workflows.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def load_bootstrap_workflow():
+    workflow_path = ROOT / ".github" / "workflows" / "bootstrap-db.yml"
+    assert workflow_path.exists(), "CI bootstrap workflow must exist"
+    return yaml.safe_load(workflow_path.read_text())
+
+
+def test_ci_bootstrap_workflow_runs_against_pgvector_postgres():
+    workflow = load_bootstrap_workflow()
+
+    job = workflow["jobs"]["bootstrap-db"]
+    postgres = job["services"]["postgres"]
+
+    assert "pull_request" in workflow["on"]
+    assert workflow["on"]["push"]["branches"] == ["main"]
+    assert postgres["image"] == "pgvector/pgvector:pg17"
+    assert postgres["ports"] == ["5432:5432"]
+    assert postgres["env"] == {
+        "POSTGRES_DB": "reai",
+        "POSTGRES_USER": "reai",
+        "POSTGRES_PASSWORD": "reai",
+        "POSTGRES_INITDB_ARGS": "-E UTF8 --locale=C",
+    }
+    assert "pg_isready -U reai -d reai" in postgres["options"]
+
+
+def test_ci_bootstrap_workflow_documents_reproducible_commands():
+    workflow = load_bootstrap_workflow()
+
+    job = workflow["jobs"]["bootstrap-db"]
+    uv_step = next(step for step in job["steps"] if step["name"] == "Set up uv")
+    run_commands = "\n".join(
+        step["run"]
+        for step in job["steps"]
+        if "run" in step
+    )
+
+    assert uv_step["uses"] == "astral-sh/setup-uv@v8.1.0"
+    assert (
+        "PYTHONPATH=. uv run python scripts/bootstrap_db.py "
+        "--database-url postgresql+psycopg2://reai:reai@localhost:5432/reai"
+    ) in run_commands
+    assert (
+        "PYTHONPATH=. uv run pytest "
+        "tests/test_bootstrap_db.py tests/test_local_dev_setup.py"
+    ) in run_commands


### PR DESCRIPTION
## Summary

- Add a GitHub Actions workflow that provisions `pgvector/pgvector:pg17` for bootstrap validation.
- Run `scripts/bootstrap_db.py --database-url ...` against the CI PostgreSQL service.
- Run the focused bootstrap/local setup tests in CI.
- Add a workflow contract test so the pgvector service and reproducible commands stay explicit.

## Validation

- `PYTHONPATH=. uv run pytest tests/test_ci_workflows.py tests/test_bootstrap_db.py tests/test_local_dev_setup.py`
- Result: 17 passed, 1 existing SQLAlchemy deprecation warning.

Closes #74.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a CI workflow to validate local database bootstrapping in development workflows.
  * Added tests that verify the new workflow's configuration and reproducibility.

Note: This release contains infrastructure and test improvements only; there are no user-facing feature changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->