### PR TITLE
[codex] Prove backend datamart serving readiness

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -41,11 +41,11 @@ services:
     environment:
       TEST_MINIO_ROOT_USER: ${TEST_MINIO_ROOT_USER:-minio}
       TEST_MINIO_ROOT_PASSWORD: ${TEST_MINIO_ROOT_PASSWORD:-minio123}
-      TEST_MINIO_BUCKET: ${TEST_MINIO_BUCKET:-reai-data}
+      MINIO_BUCKET: ${MINIO_BUCKET:-reai-data}
     entrypoint: >
       /bin/sh -c "
       mc alias set local http://test-minio:9000 $$TEST_MINIO_ROOT_USER $$TEST_MINIO_ROOT_PASSWORD &&
-      mc mb --ignore-existing local/$$TEST_MINIO_BUCKET
+      mc mb --ignore-existing local/$$MINIO_BUCKET
       "
     restart: "no"
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,14 +1,13 @@
 services:
   test-postgres:
     image: pgvector/pgvector:pg17
-    container_name: reai-test-postgres
     environment:
       POSTGRES_DB: testdb
       POSTGRES_USER: testuser
       POSTGRES_PASSWORD: testpass
       POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     ports:
-      - "5433:5432"
+      - "${TEST_POSTGRES_PORT:-5433}:5432"
     volumes:
       - test-postgres-data-pg17:/var/lib/postgresql/data
     healthcheck:
@@ -17,6 +16,41 @@ services:
       timeout: 5s
       retries: 5
 
+  test-minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${TEST_MINIO_ROOT_USER:-minio}
+      MINIO_ROOT_PASSWORD: ${TEST_MINIO_ROOT_PASSWORD:-minio123}
+    ports:
+      - "${TEST_MINIO_API_PORT:-9002}:9000"
+      - "${TEST_MINIO_CONSOLE_PORT:-9003}:9001"
+    volumes:
+      - test-minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  test-minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      test-minio:
+        condition: service_healthy
+    environment:
+      TEST_MINIO_ROOT_USER: ${TEST_MINIO_ROOT_USER:-minio}
+      TEST_MINIO_ROOT_PASSWORD: ${TEST_MINIO_ROOT_PASSWORD:-minio123}
+      TEST_MINIO_BUCKET: ${TEST_MINIO_BUCKET:-reai-data}
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://test-minio:9000 $$TEST_MINIO_ROOT_USER $$TEST_MINIO_ROOT_PASSWORD &&
+      mc mb --ignore-existing local/$$TEST_MINIO_BUCKET
+      "
+    restart: "no"
+
 volumes:
   test-postgres-data-pg17:
+    driver: local
+  test-minio-data:
     driver: local

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,8 +20,8 @@ services:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: ${TEST_MINIO_ROOT_USER:-minio}
-      MINIO_ROOT_PASSWORD: ${TEST_MINIO_ROOT_PASSWORD:-minio123}
+      MINIO_ROOT_USER: ${MINIO_ACCESS_KEY:-minio}
+      MINIO_ROOT_PASSWORD: ${MINIO_SECRET_KEY:-minio123}
     ports:
       - "${TEST_MINIO_API_PORT:-9002}:9000"
       - "${TEST_MINIO_CONSOLE_PORT:-9003}:9001"
@@ -39,12 +39,12 @@ services:
       test-minio:
         condition: service_healthy
     environment:
-      TEST_MINIO_ROOT_USER: ${TEST_MINIO_ROOT_USER:-minio}
-      TEST_MINIO_ROOT_PASSWORD: ${TEST_MINIO_ROOT_PASSWORD:-minio123}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-minio}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-minio123}
       MINIO_BUCKET: ${MINIO_BUCKET:-reai-data}
     entrypoint: >
       /bin/sh -c "
-      mc alias set local http://test-minio:9000 $$TEST_MINIO_ROOT_USER $$TEST_MINIO_ROOT_PASSWORD &&
+      mc alias set local http://test-minio:9000 $$MINIO_ACCESS_KEY $$MINIO_SECRET_KEY &&
       mc mb --ignore-existing local/$$MINIO_BUCKET
       "
     restart: "no"

--- a/docs/backend-datamart-contract.md
+++ b/docs/backend-datamart-contract.md
@@ -1,0 +1,333 @@
+# Backend Data Mart Contract
+
+This document defines the first-pass backend-facing physical table contract for the current Gold/data mart outputs. Backend consumers may read these physical tables directly, but only the four tables listed here are in scope.
+
+## Contract boundary
+
+| Table | Backend use | Contract owner | Source evidence |
+|---|---|---|---|
+| `fact_service_review_daily` | Service summary dashboard metrics by date, service, and platform | Data pipeline / backend integration | `sql/schema_v4.sql:476-501`, `src/models/fact_service_review_daily.py:13-39`, `src/gold/aggregator.py:275-319` |
+| `fact_service_aspect_daily` | Keyword/aspect trend and cloud metrics | Data pipeline / backend integration | `sql/schema_v4.sql:507-522`, `src/models/fact_service_aspect_daily.py:12-28`, `src/gold/aggregator.py:321-345` |
+| `fact_category_radar_scores` | Category radar chart metrics | Data pipeline / backend integration | `sql/schema_v4.sql:528-543`, `src/models/fact_category_radar_scores.py:15-36`, `src/gold/aggregator.py:347-371` |
+| `srv_daily_review_list` | Hot review-list serving table | Data pipeline / backend integration | `sql/schema_v4.sql:553-584`, `src/models/srv_daily_review_list.py:16-49`, `src/gold/aggregator.py:373-420` |
+
+Out of scope for this handoff:
+
+- Backend API endpoints, routers, controllers, DTOs, or service-layer code.
+- New `fact_*`, `dim_*`, `srv_*`, view, or materialized-view tables.
+- Broad `GoldAggregator` redesigns or unrelated data-quality framework work.
+
+## Global semantics
+
+### Date/timezone semantics
+
+- `fact_* .date` is the aggregation date generated from `DATE_TRUNC('day', review_master_index.review_created_at)::date` in the current aggregator SQL.
+- `srv_daily_review_list.date` is the partition key and is generated from the same `DATE_TRUNC('day', review_master_index.review_created_at)::date` expression in the current aggregator. Schema comments describe it as typically `DATE(reviewed_at)`.
+- `review_master_index.review_created_at` stores platform review time. The schema comments mark mart dates as UTC, so backend consumers should treat the produced `date` as a UTC reporting date and keep the PostgreSQL session timezone stable when running aggregation jobs.
+- If future aggregation changes alter timezone normalization, that is a semantic contract change even if the SQL column type remains `DATE`.
+
+### Referential behavior
+
+All four contract tables currently reference `app_service(service_id)` with `ON DELETE CASCADE` in `sql/schema_v4.sql:641-667`. Backend consumers should treat service deletion as removing matching mart rows. Changing or removing this cascade behavior is backend-impacting.
+
+### TTL/partition retention
+
+`srv_daily_review_list` is a partitioned hot serving table with TTL intent. The table comment states a 7-14 day hot window, and `GoldAggregator.run(..., retention_days=14)` uses a default 14-day partition retention argument. Backend review-list reads should target the hot window; long-range history is a separate data-product decision.
+
+### Nullability and availability
+
+- `fact_* .service_id` columns are non-null contract keys.
+- Nullable `srv_daily_review_list.service_id`: `srv_daily_review_list.service_id` is currently nullable. Service-scoped backend reads must either filter `service_id = :service_id` and naturally exclude null-service rows, or handle null-service rows explicitly in unscoped review feeds.
+- Numeric aggregate fields may be null unless the current schema marks them `NOT NULL`; consumers should use `COALESCE` at presentation boundaries when a zero default is required.
+
+## Column contract matrices
+
+### `fact_service_review_daily`
+
+Primary key: `(date, service_id, platform_type)`.
+
+Required serving index: `idx_fact_service_review_daily_date` on `(date)`.
+
+| Column | PostgreSQL type | Nullable | Key / index role | Semantic meaning | Example value | Backend usage |
+|---|---|---:|---|---|---|---|
+| `date` | `DATE` | No | PK member; covered by `idx_fact_service_review_daily_date` | UTC reporting date derived from review creation time | `2026-05-01` | Date-range dashboard filter |
+| `service_id` | `UUID` | No | PK member; FK to `app_service(service_id)` | Logical service identifier | `:service_id` | Service-scoped dashboard filter |
+| `platform_type` | `platform_type` enum | No | PK member | Source platform: `APPSTORE` or `PLAYSTORE` | `PLAYSTORE` | Platform breakdown/filter |
+| `total_review_cnt` | `INT` | Yes | Metric | Count of analyzed reviews in the group | `128` | Total review volume |
+| `action_required_cnt` | `INT` | Yes | Metric | Count of reviews requiring action | `11` | Operations workload indicator |
+| `attention_required_cnt` | `INT` | Yes | Metric | Count of reviews requiring attention | `24` | Monitoring indicator |
+| `pos_count` | `INT` | Yes | Metric | Count of reviews with average sentiment score `>= 0.5` | `92` | Positive review count |
+| `neg_count` | `INT` | Yes | Metric | Count of reviews with average sentiment score `< 0.5` | `36` | Negative review count |
+| `avg_rating` | `FLOAT` | Yes | Metric | Average platform rating | `4.21` | Rating trend |
+| `action_ratio` | `FLOAT` | Yes | Metric | `action_required_cnt / total_review_cnt`, rounded by current aggregator SQL | `0.0859` | Action-required rate |
+
+### `fact_service_aspect_daily`
+
+Primary key: `(date, service_id, keyword)`.
+
+Required serving index: `idx_fact_service_aspect_daily_date` on `(date)`.
+
+| Column | PostgreSQL type | Nullable | Key / index role | Semantic meaning | Example value | Backend usage |
+|---|---|---:|---|---|---|---|
+| `date` | `DATE` | No | PK member; covered by `idx_fact_service_aspect_daily_date` | UTC reporting date derived from review creation time | `2026-05-01` | Date-range trend filter |
+| `service_id` | `UUID` | No | PK member; FK to `app_service(service_id)` | Logical service identifier | `:service_id` | Service-scoped trend filter |
+| `keyword` | `TEXT` | No | PK member | Extracted aspect keyword | `login` | Keyword label |
+| `mention_cnt` | `INT` | Yes | Metric | Number of keyword mentions | `37` | Cloud weight / ranking |
+| `avg_sentiment_score` | `FLOAT` | Yes | Metric | Average sentiment score for the keyword | `0.68` | Keyword sentiment trend |
+
+### `fact_category_radar_scores`
+
+Primary key: `(date, service_id, category_type)`.
+
+Required serving index: `idx_fact_category_radar_scores_date` on `(date)`.
+
+Current category allow-list from the aggregator: `USABILITY`, `STABILITY`, `DESIGN`, `CUSTOMER_SUPPORT`, `SPEED`.
+
+| Column | PostgreSQL type | Nullable | Key / index role | Semantic meaning | Example value | Backend usage |
+|---|---|---:|---|---|---|---|
+| `date` | `DATE` | No | PK member; covered by `idx_fact_category_radar_scores_date` | UTC reporting date derived from review creation time | `2026-05-01` | Radar date filter |
+| `service_id` | `UUID` | No | PK member; FK to `app_service(service_id)` | Logical service identifier | `:service_id` | Service-scoped radar filter |
+| `category_type` | `category_type` enum | No | PK member | Radar category | `USABILITY` | Radar axis |
+| `avg_sentiment_score` | `FLOAT` | Yes | Metric | Average sentiment score for the category | `0.72` | Radar score |
+| `review_cnt` | `INT` | Yes | Metric | Distinct review count contributing to the category | `54` | Sample-size display / confidence hint |
+
+### `srv_daily_review_list`
+
+Primary key: `(review_id, date)`.
+
+Required serving indexes:
+
+- `idx_srv_daily_review_list_service_id` on `(service_id)`.
+- `idx_srv_daily_review_list_date` on `(date)`.
+- `idx_srv_daily_review_list_is_action_required` partial index on `(is_action_required)` where `is_action_required = true`.
+- `idx_srv_daily_review_list_keyword` GIN index on `(keyword)`.
+
+The table is partitioned by `RANGE (date)`.
+
+| Column | PostgreSQL type | Nullable | Key / index role | Semantic meaning | Example value | Backend usage |
+|---|---|---:|---|---|---|---|
+| `review_id` | `UUID` | No | PK member | Global review identifier | `:review_id` | Detail lookup / pagination tie-breaker |
+| `date` | `DATE` | No | PK member; partition key; covered by `idx_srv_daily_review_list_date` | Review-list partition/reporting date | `2026-05-01` | Hot-window and partition-pruning filter |
+| `service_id` | `UUID` | Yes | FK to `app_service(service_id)`; covered by `idx_srv_daily_review_list_service_id` | Logical service identifier when available | `:service_id` | Service-scoped review list |
+| `refined_text` | `TEXT` | Yes | Display field | Preprocessed review text | `The latest update is slow.` | Review body snippet |
+| `review_summary` | `TEXT` | Yes | Display field | LLM one-sentence summary | `User reports slow update.` | Summary display |
+| `rating` | `INT` | Yes | Display/filter field | Platform star rating | `2` | Rating display/filter |
+| `reviewed_at` | `TIMESTAMPTZ` | Yes | Sort/display field | Original platform review timestamp | `2026-05-01T10:15:00Z` | Stable ordering and display |
+| `sentiment_score` | `FLOAT` | Yes | Metric | Average sentiment score for the review | `0.32` | Sentiment display/filter |
+| `is_action_required` | `BOOLEAN` | Yes | Covered by partial action index for `true` rows | Whether the review needs action | `true` | Action queue filter |
+| `is_attention_required` | `BOOLEAN` | Yes | Filter/display field | Whether the review needs attention | `false` | Attention queue filter |
+| `assigned_dept` | `TEXT[]` | Yes | Display/filter candidate | Assigned department list | `{support,product}` | Routing display |
+| `keyword` | `TEXT[]` | Yes | GIN-indexed keyword array | Review keyword array | `{login,crash}` | Keyword filtering/search |
+| `confidence` | `FLOAT` | Yes | Metric | Department assignment confidence | `0.91` | Routing confidence display |
+
+## Backend query examples
+
+The examples use named bind parameters. They intentionally avoid hardcoded service IDs, date ranges, and pagination cursors.
+
+### Service summary dashboard
+
+Reads `fact_service_review_daily` by date range, service, and optional platform.
+
+```sql
+SELECT
+  date,
+  platform_type,
+  COALESCE(total_review_cnt, 0) AS total_review_cnt,
+  COALESCE(action_required_cnt, 0) AS action_required_cnt,
+  COALESCE(attention_required_cnt, 0) AS attention_required_cnt,
+  COALESCE(pos_count, 0) AS pos_count,
+  COALESCE(neg_count, 0) AS neg_count,
+  avg_rating,
+  action_ratio
+FROM fact_service_review_daily
+WHERE service_id = :service_id
+  AND date BETWEEN :start_date AND :end_date
+  AND (:platform_type IS NULL OR platform_type = :platform_type)
+ORDER BY date ASC, platform_type ASC;
+```
+
+### Keyword/aspect trend
+
+Reads `fact_service_aspect_daily` by date range and service, ranking keywords by mentions.
+
+```sql
+SELECT
+  date,
+  keyword,
+  COALESCE(mention_cnt, 0) AS mention_cnt,
+  avg_sentiment_score
+FROM fact_service_aspect_daily
+WHERE service_id = :service_id
+  AND date BETWEEN :start_date AND :end_date
+ORDER BY date ASC, mention_cnt DESC, keyword ASC
+LIMIT :limit;
+```
+
+### Radar chart
+
+Reads `fact_category_radar_scores` by date, service, and optional category list.
+
+```sql
+SELECT
+  category_type,
+  avg_sentiment_score,
+  COALESCE(review_cnt, 0) AS review_cnt
+FROM fact_category_radar_scores
+WHERE service_id = :service_id
+  AND date = :date
+  AND (:category_types IS NULL OR category_type = ANY(:category_types))
+ORDER BY category_type ASC;
+```
+
+### Review list with stable pagination order
+
+Service-scoped reads naturally exclude rows where `service_id IS NULL` by requiring `service_id = :service_id`. For unscoped operational feeds, decide explicitly whether null-service rows should be included.
+
+```sql
+SELECT
+  review_id,
+  date,
+  service_id,
+  reviewed_at,
+  rating,
+  refined_text,
+  review_summary,
+  sentiment_score,
+  is_action_required,
+  is_attention_required,
+  assigned_dept,
+  keyword,
+  confidence
+FROM srv_daily_review_list
+WHERE service_id = :service_id
+  AND date BETWEEN :start_date AND :end_date
+  AND (:action_required_only IS NOT TRUE OR is_action_required = true)
+  AND (
+    :cursor_reviewed_at IS NULL
+    OR (reviewed_at, review_id) < (:cursor_reviewed_at, :cursor_review_id)
+  )
+ORDER BY reviewed_at DESC NULLS LAST, review_id DESC
+LIMIT :limit;
+```
+
+Current serving indexes support service, date, action-required, and keyword filtering, but there is no composite pagination index for `(service_id, date, reviewed_at, review_id)` or equivalent. Do not promise cursor-pagination latency as a hard contract until a follow-up index decision is made and migrated.
+
+### Keyword-filtered review list
+
+```sql
+SELECT
+  review_id,
+  date,
+  service_id,
+  reviewed_at,
+  rating,
+  refined_text,
+  keyword
+FROM srv_daily_review_list
+WHERE service_id = :service_id
+  AND date BETWEEN :start_date AND :end_date
+  AND keyword @> ARRAY[:keyword]::text[]
+ORDER BY reviewed_at DESC NULLS LAST, review_id DESC
+LIMIT :limit;
+```
+
+## Breaking-change policy and compatibility rules
+
+A change is backend-breaking when it does any of the following to one of the four contract tables:
+
+- Removes, renames, or repurposes a contract table.
+- Removes, renames, or repurposes a contract column.
+- Changes PostgreSQL type, enum domain, nullability, primary key, partition key, foreign-key cascade behavior, or required serving index.
+- Changes aggregate meaning, timezone/date semantics, retention semantics, or row inclusion/exclusion semantics even when SQL types remain unchanged.
+- Adds a backend dependency on a new mart object without updating this document and the regression contract tests.
+
+Breaking changes require:
+
+1. Alembic revision.
+2. Contract document update.
+3. Contract regression test update.
+4. Backend coordination note that names the migration impact and rollout expectation.
+
+Future schema changes should follow `docs/schema-management.md`; direct edits to the baseline `sql/schema_v4.sql` are not the normal forward-migration path.
+
+## Docker validation and verification commands
+
+Focused contract and serving-readiness command expected for this handoff:
+
+```bash
+PYTHONPATH=. uv run pytest tests/test_backend_datamart_contract.py -q
+```
+
+Related existing suite:
+
+```bash
+PYTHONPATH=. uv run pytest tests/test_gold_aggregator.py tests/test_database_schema.py -q
+```
+
+Docker PostgreSQL schema proof:
+
+```bash
+docker compose -f docker-compose.test.yml up -d test-postgres
+TEST_DATABASE_URL="${TEST_DATABASE_URL:-postgresql://testuser:testpass@localhost:5433/testdb}" \
+PYTHONPATH=. uv run pytest tests/test_backend_datamart_contract.py -q
+```
+
+The focused contract suite includes both schema/query contract checks and a
+serving-readiness row proof. The row proof seeds upstream analyzed review rows,
+invokes the real `aggregate` pipeline step through `run_steps(["aggregate"],
+target_date=...)`, and asserts generated rows plus backend-facing semantics in
+all four contract tables.
+
+## Serving readiness proof
+
+The automated readiness proof intentionally exercises the real aggregate step
+instead of direct mart inserts:
+
+1. Seed a committed PostgreSQL fixture with upstream rows in `app_service`,
+   `apps`, `review_master_index`, `app_reviews`, `reviews_preprocessed`,
+   `review_action_analysis`, `review_aspects`, and `reviews_assigned`.
+2. Set `DATABASE_URL` to the isolated test PostgreSQL URL.
+3. Run the pipeline step dispatcher with `aggregate` and an explicit
+   `target_date`.
+4. Assert generated rows in:
+   - `fact_service_review_daily`
+   - `fact_service_aspect_daily`
+   - `fact_category_radar_scores`
+   - `srv_daily_review_list`
+5. Assert semantic values used by backend consumers: review counts, action and
+   attention flags, sentiment aggregates, category scores, review summary,
+   assigned departments, keywords, and confidence.
+
+This proof covers AC2-AC4 for the aggregate serving boundary. Full live crawl,
+load, cleanse, and Gold analysis remain manual release evidence because they can
+depend on external store availability and LLM credentials.
+
+## Manual live crawl smoke proof
+
+Before release, record a manual live smoke run separately from PR automation:
+
+```bash
+docker compose up -d postgres minio minio-init
+PYTHONPATH=. uv run python scripts/bootstrap_db.py
+PYTHONPATH=. uv run python scripts/crawl_reviews.py
+PYTHONPATH=. uv run python scripts/load_reviews.py
+PYTHONPATH=. uv run python scripts/cleanse_reviews.py --date "$(date -I)"
+PYTHONPATH=. uv run python scripts/run_pipeline.py --steps gold,aggregate --target-date "$(date -I)"
+```
+
+Capture the command timestamp, service/source target, and these row counts:
+
+```sql
+SELECT 'fact_service_review_daily' AS table_name, COUNT(*) FROM fact_service_review_daily WHERE date = :target_date
+UNION ALL
+SELECT 'fact_service_aspect_daily', COUNT(*) FROM fact_service_aspect_daily WHERE date = :target_date
+UNION ALL
+SELECT 'fact_category_radar_scores', COUNT(*) FROM fact_category_radar_scores WHERE date = :target_date
+UNION ALL
+SELECT 'srv_daily_review_list', COUNT(*) FROM srv_daily_review_list WHERE date = :target_date;
+```
+
+Store the evidence with the release notes or PR checklist. If the crawl or LLM
+analysis is flaky because of external network, store, or credential state,
+record the caveat and keep the automated PostgreSQL readiness proof as the PR
+gate.

--- a/docs/backend-datamart-serving-readiness.md
+++ b/docs/backend-datamart-serving-readiness.md
@@ -1,0 +1,79 @@
+# Backend Datamart Serving Readiness Runbook
+
+This runbook records the manual release proof for backend-facing datamarts. It
+is intentionally separate from PR automation because live crawls depend on
+external store/network state and production credentials are out of scope.
+
+## Automated local proof
+
+The CI/local test proof uses Docker PostgreSQL from `docker-compose.test.yml`,
+seeds analyzed upstream pipeline tables, invokes the real aggregate CLI
+entrypoint, and asserts rows plus backend semantics in:
+
+- `fact_service_review_daily`
+- `fact_service_aspect_daily`
+- `fact_category_radar_scores`
+- `srv_daily_review_list`
+
+Run the full suite before completion:
+
+```bash
+PYTHONPATH=. uv run pytest -q
+```
+
+Targeted readiness proof:
+
+```bash
+PYTHONPATH=. uv run pytest -q tests/test_backend_datamart_serving_readiness.py
+```
+
+## Manual live crawl smoke
+
+Start local PostgreSQL and MinIO, then run host-side Python entrypoints:
+
+```bash
+docker compose up -d
+PYTHONPATH=. uv run python scripts/bootstrap_db.py
+PYTHONPATH=. uv run python scripts/crawl_reviews.py
+PYTHONPATH=. uv run python scripts/load_reviews.py
+PYTHONPATH=. uv run python scripts/cleanse_reviews.py --date YYYY-MM-DD
+PYTHONPATH=. uv run python -m src.pipeline.cli --steps aggregate --target-date YYYY-MM-DD
+```
+
+Use the date actually produced by the crawl in place of `YYYY-MM-DD`. MinIO
+should contain Bronze/Silver Parquet evidence under the configured bucket before
+the aggregate step is accepted as release evidence.
+
+## Evidence path
+
+Store manual smoke evidence under:
+
+```text
+docs/evidence/backend-datamart-serving-readiness/YYYY-MM-DD.md
+```
+
+The evidence file must include:
+
+| Field | Required content |
+|---|---|
+| `timestamp` | Absolute timestamp with timezone for the smoke run. |
+| `crawl command used` | Exact crawl command and config target. |
+| `source/service target` | Store/platform app or service target used. |
+| `MinIO evidence` | Bucket/key prefix for produced Bronze and Silver objects. |
+| `fact_service_review_daily` | Row count for the target date. |
+| `fact_service_aspect_daily` | Row count for the target date. |
+| `fact_category_radar_scores` | Row count for the target date. |
+| `srv_daily_review_list` | Row count for the target date. |
+| `failures or caveats` | External flakiness, empty crawl caveats, or `none`. |
+
+Suggested SQL for counts:
+
+```sql
+SELECT 'fact_service_review_daily' AS table_name, COUNT(*) FROM fact_service_review_daily WHERE date = DATE 'YYYY-MM-DD'
+UNION ALL
+SELECT 'fact_service_aspect_daily', COUNT(*) FROM fact_service_aspect_daily WHERE date = DATE 'YYYY-MM-DD'
+UNION ALL
+SELECT 'fact_category_radar_scores', COUNT(*) FROM fact_category_radar_scores WHERE date = DATE 'YYYY-MM-DD'
+UNION ALL
+SELECT 'srv_daily_review_list', COUNT(*) FROM srv_daily_review_list WHERE date = DATE 'YYYY-MM-DD';
+```

--- a/docs/evidence/backend-datamart-serving-readiness/README.md
+++ b/docs/evidence/backend-datamart-serving-readiness/README.md
@@ -1,0 +1,60 @@
+# Backend Datamart Serving Readiness Evidence
+
+This directory is the release evidence path for backend datamart serving readiness.
+Automated PR checks prove the local Docker PostgreSQL + MinIO integration path with
+a deterministic fixture. Live crawl remains a manual smoke proof because external
+store/network availability and production credentials are not PR-gate inputs.
+
+## Automated local proof
+
+Start the isolated test services, then run the readiness proof:
+
+```bash
+docker compose -f docker-compose.test.yml up -d test-postgres test-minio test-minio-init
+PYTHONPATH=. TEST_MINIO_ENDPOINT=localhost:9002 TEST_MINIO_BUCKET=reai-test-data \
+  uv run pytest -q tests/test_backend_datamart_serving_readiness.py
+```
+
+The test writes and reads a real MinIO Parquet object, invokes the real pipeline
+CLI aggregate entrypoint, and asserts generated rows plus semantics for:
+
+- `fact_service_review_daily`
+- `fact_service_aspect_daily`
+- `fact_category_radar_scores`
+- `srv_daily_review_list`
+
+## Manual live crawl smoke
+
+Use this command only in a local release-smoke environment with real non-production
+credentials and store/network access:
+
+```bash
+PYTHONPATH=. uv run python scripts/bootstrap_db.py
+PYTHONPATH=. uv run python scripts/run_pipeline.py \
+  --steps crawl,load,gold,aggregate \
+  --target-date YYYY-MM-DD \
+  --batch-size 100
+```
+
+Record each run under this directory with a timestamped markdown file such as
+`docs/evidence/backend-datamart-serving-readiness/2026-05-03-live-smoke.md`.
+Include:
+
+| Field | Evidence to record |
+|---|---|
+| Crawl command | Exact command and config file used |
+| Source/service target | App/store/service target and environment name |
+| Timestamp | Start/end time with timezone |
+| MinIO proof | Bucket, object prefix, and object count/path sample |
+| Mart counts | Row counts for all four backend-facing mart tables |
+| Semantic sample | One representative backend-facing row per mart or query output |
+| Caveats | External API/network/key issues, if any |
+
+Suggested SQL for mart counts:
+
+```sql
+SELECT 'fact_service_review_daily' AS table_name, COUNT(*) FROM fact_service_review_daily
+UNION ALL SELECT 'fact_service_aspect_daily', COUNT(*) FROM fact_service_aspect_daily
+UNION ALL SELECT 'fact_category_radar_scores', COUNT(*) FROM fact_category_radar_scores
+UNION ALL SELECT 'srv_daily_review_list', COUNT(*) FROM srv_daily_review_list;
+```

--- a/docs/evidence/backend-datamart-serving-readiness/README.md
+++ b/docs/evidence/backend-datamart-serving-readiness/README.md
@@ -1,9 +1,11 @@
 # Backend Datamart Serving Readiness Evidence
 
 This directory is the release evidence path for backend datamart serving readiness.
-Automated PR checks prove the local Docker PostgreSQL + MinIO integration path with
-a deterministic fixture. Live crawl remains a manual smoke proof because external
-store/network availability and production credentials are not PR-gate inputs.
+Automated PR checks prove the local Docker PostgreSQL aggregate path with a
+deterministic fixture. The Docker test stack also provisions MinIO with the same
+runtime environment names used by the pipeline, but live object proof remains a
+manual smoke proof because external store/network availability and production
+credentials are not PR-gate inputs.
 
 ## Automated local proof
 
@@ -11,12 +13,13 @@ Start the isolated test services, then run the readiness proof:
 
 ```bash
 docker compose -f docker-compose.test.yml up -d test-postgres test-minio test-minio-init
-PYTHONPATH=. TEST_MINIO_ENDPOINT=localhost:9002 TEST_MINIO_BUCKET=reai-test-data \
+PYTHONPATH=. MINIO_ENDPOINT=localhost:9002 MINIO_ACCESS_KEY=minio \
+  MINIO_SECRET_KEY=minio123 MINIO_BUCKET=reai-data \
   uv run pytest -q tests/test_backend_datamart_serving_readiness.py
 ```
 
-The test writes and reads a real MinIO Parquet object, invokes the real pipeline
-CLI aggregate entrypoint, and asserts generated rows plus semantics for:
+The automated test seeds upstream PostgreSQL pipeline tables, invokes the real
+pipeline CLI aggregate entrypoint, and asserts generated rows plus semantics for:
 
 - `fact_service_review_daily`
 - `fact_service_aspect_daily`

--- a/docs/local-development.md
+++ b/docs/local-development.md
@@ -61,6 +61,56 @@ Notes:
 - Replace `YYYY-MM-DD` with the Bronze partition date you actually crawled, or use a shell expression such as `$(date -I)` for today's partition.
 - Gold analyze/aggregate steps require a real `OPENAI_API_KEY`.
 
+## Prove backend datamart serving readiness
+
+After the minimum ETL flow and Gold analysis have completed for a date, run the
+real pipeline entrypoint for the backend-facing mart step:
+
+```bash
+PYTHONPATH=. uv run python scripts/run_pipeline.py --steps gold,aggregate --target-date YYYY-MM-DD
+```
+
+For a PR-safe PostgreSQL proof that does not require live store or LLM access,
+run the focused contract suite against the Docker test database:
+
+```bash
+docker compose -f docker-compose.test.yml up -d test-postgres
+TEST_DATABASE_URL="${TEST_DATABASE_URL:-postgresql://testuser:testpass@localhost:5433/testdb}" \
+PYTHONPATH=. uv run pytest tests/test_backend_datamart_contract.py -q
+```
+
+This suite seeds upstream analyzed review rows, invokes the real `aggregate`
+step dispatcher, and asserts generated rows plus backend-facing semantics in:
+
+- `fact_service_review_daily`
+- `fact_service_aspect_daily`
+- `fact_category_radar_scores`
+- `srv_daily_review_list`
+
+## Manual live crawl smoke evidence
+
+For release evidence, keep live crawl proof separate from PR automation because
+store responses and LLM credentials can be externally flaky. Record:
+
+- crawl command used
+- source/service target
+- timestamp
+- `target_date`
+- row counts for all four backend-facing mart tables
+- failures or caveats
+
+Use this SQL shape for the row-count evidence:
+
+```sql
+SELECT 'fact_service_review_daily' AS table_name, COUNT(*) FROM fact_service_review_daily WHERE date = :target_date
+UNION ALL
+SELECT 'fact_service_aspect_daily', COUNT(*) FROM fact_service_aspect_daily WHERE date = :target_date
+UNION ALL
+SELECT 'fact_category_radar_scores', COUNT(*) FROM fact_category_radar_scores WHERE date = :target_date
+UNION ALL
+SELECT 'srv_daily_review_list', COUNT(*) FROM srv_daily_review_list WHERE date = :target_date;
+```
+
 ## Verify results
 
 - DataGrip / PostgreSQL:

--- a/src/crawlers/base_crawler.py
+++ b/src/crawlers/base_crawler.py
@@ -289,6 +289,86 @@ class BaseCrawler(ABC):
         finally:
             session.close()
 
+    def save_crawl_batch(
+        self,
+        app_id: str,
+        app_name: Optional[str],
+        reviews_data: List[Dict[str, Any]],
+        build_parquet_records_func: Callable,
+    ) -> Tuple[Optional[UUID], int, Optional[Path]]:
+        """앱 단위 리뷰를 로컬 Parquet 파일과 PENDING ingestion_batch로 저장."""
+        from ..crawlers.exceptions import ParquetWriteError
+        from ..models.ingestion_batch import IngestionBatch
+        from ..models.enums import IngestionBatchStatusType
+
+        if not self.enable_parquet:
+            return None, 0, None
+
+        session = self.db_connector.get_session()
+        try:
+            platform_type = self._get_platform_type()
+            app = self._get_or_create_app(session, app_id, app_name, platform_type)
+            existing_platform_ids = self._get_existing_platform_ids(
+                session, app.app_id, platform_type
+            )
+            memory_key = (platform_type.value, app_id)
+            seen_by_app = getattr(self, "_seen_crawl_platform_ids", {})
+            existing_platform_ids.update(seen_by_app.get(memory_key, set()))
+            new_reviews_data = self._filter_new_reviews(reviews_data, existing_platform_ids)
+
+            if not new_reviews_data:
+                session.commit()
+                return None, 0, None
+
+            review_id_map, reviewed_at_cache = self._create_review_id_and_timestamp_caches(
+                new_reviews_data,
+                self._parse_reviewed_at,
+            )
+            parquet_records = build_parquet_records_func(
+                new_reviews_data,
+                review_id_map,
+                reviewed_at_cache,
+                app,
+            )
+
+            if not parquet_records:
+                session.commit()
+                return None, 0, None
+
+            try:
+                parquet_path = self.parquet_writer.write_batch(parquet_records)
+            except Exception as exc:
+                session.rollback()
+                raise ParquetWriteError(str(exc)) from exc
+
+            now = datetime.now(timezone.utc)
+            batch = IngestionBatch(
+                batch_id=uuid7(),
+                source_type=platform_type,
+                platform_app_id=app_id,
+                app_name=app_name,
+                storage_path=str(parquet_path),
+                file_format="parquet",
+                record_count=len(parquet_records),
+                status=IngestionBatchStatusType.PENDING,
+                retry_count=0,
+                max_retries=self.max_retries,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(batch)
+            session.commit()
+
+            seen_by_app.setdefault(memory_key, set()).update(review_id_map)
+            self._seen_crawl_platform_ids = seen_by_app
+            return batch.batch_id, len(parquet_records), parquet_path
+
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
     def save_daily_batch(
         self,
         all_records: List,

--- a/src/crawlers/base_crawler.py
+++ b/src/crawlers/base_crawler.py
@@ -197,10 +197,12 @@ class BaseCrawler(ABC):
             List of new (non-duplicate) reviews
         """
         new_reviews = []
+        seen_platform_ids = set(existing_platform_ids)
         for review in reviews_data:
             platform_review_id = self._extract_platform_review_id(review)
-            if platform_review_id and platform_review_id not in existing_platform_ids:
+            if platform_review_id and platform_review_id not in seen_platform_ids:
                 new_reviews.append(review)
+                seen_platform_ids.add(platform_review_id)
 
         return new_reviews
 

--- a/src/crawlers/base_crawler.py
+++ b/src/crawlers/base_crawler.py
@@ -357,7 +357,12 @@ class BaseCrawler(ABC):
                 updated_at=now,
             )
             session.add(batch)
-            session.commit()
+            try:
+                session.commit()
+            except Exception:
+                session.rollback()
+                self._cleanup_local_parquet_artifact(parquet_path)
+                raise
 
             seen_by_app.setdefault(memory_key, set()).update(review_id_map)
             self._seen_crawl_platform_ids = seen_by_app
@@ -368,6 +373,16 @@ class BaseCrawler(ABC):
             raise
         finally:
             session.close()
+
+    def _cleanup_local_parquet_artifact(self, parquet_path: Path) -> None:
+        """Remove a local Parquet artifact after DB registration failure."""
+        try:
+            Path(parquet_path).unlink(missing_ok=True)
+            self.logger.warning(f"Rolled back orphaned local Parquet file: {parquet_path}")
+        except Exception as cleanup_err:
+            self.logger.error(
+                f"Failed to clean up orphaned local Parquet file {parquet_path}: {cleanup_err}"
+            )
 
     def save_daily_batch(
         self,

--- a/src/gold/aggregator.py
+++ b/src/gold/aggregator.py
@@ -236,7 +236,7 @@ class GoldAggregator:
             SELECT c.relname
             FROM pg_catalog.pg_inherits i
             JOIN pg_catalog.pg_class c ON c.oid = i.inhrelid
-            JOIN pg_catalog.pg_class p ON p.oid = i.inhparentid
+            JOIN pg_catalog.pg_class p ON p.oid = i.inhparent
             WHERE p.relname = 'srv_daily_review_list'
               AND c.relname ~ '^srv_daily_review_list_\d{4}_\d{2}_\d{2}$'
         """)
@@ -290,9 +290,9 @@ class GoldAggregator:
                 COUNT(DISTINCT CASE WHEN avg_sent.avg_score >= 0.5 THEN rmi.review_id END) AS pos_count,
                 COUNT(DISTINCT CASE WHEN avg_sent.avg_score <  0.5 THEN rmi.review_id END) AS neg_count,
                 ROUND(
-                    SUM(CASE WHEN raa.is_action_required THEN 1 ELSE 0 END)::FLOAT
+                    SUM(CASE WHEN raa.is_action_required THEN 1 ELSE 0 END)::NUMERIC
                     / NULLIF(COUNT(*), 0), 4
-                ) AS action_ratio
+                )::FLOAT AS action_ratio
             FROM review_master_index rmi
             JOIN review_action_analysis raa USING (review_id)
             JOIN app_reviews ar ON ar.platform_review_id = rmi.platform_review_id
@@ -387,23 +387,25 @@ class GoldAggregator:
                 raa.review_summary,
                 ar.rating,
                 rmi.review_created_at                          AS reviewed_at,
-                (SELECT AVG(sentiment_score) FROM review_aspects
-                 WHERE review_id = rmi.review_id)              AS sentiment_score,
+                (SELECT AVG(ra_sent.sentiment_score)
+                 FROM review_aspects ra_sent
+                 WHERE ra_sent.review_id = rmi.review_id)      AS sentiment_score,
                 raa.is_action_required,
                 raa.is_attention_required,
                 rvs.assigned_dept,
-                ARRAY(SELECT DISTINCT keyword FROM review_aspects
-                      WHERE review_id = rmi.review_id
-                        AND keyword IS NOT NULL)               AS keyword,
+                ARRAY(SELECT DISTINCT ra_kw.keyword
+                      FROM review_aspects ra_kw
+                      WHERE ra_kw.review_id = rmi.review_id
+                        AND ra_kw.keyword IS NOT NULL)         AS keyword,
                 rvs.confidence
             FROM review_master_index rmi
             JOIN review_action_analysis raa USING (review_id)
             JOIN app_reviews ar ON ar.platform_review_id = rmi.platform_review_id
-            LEFT JOIN reviews_preprocessed rp USING (review_id)
+            LEFT JOIN reviews_preprocessed rp ON rp.review_id = rmi.review_id
             LEFT JOIN (
                 SELECT DISTINCT ON (review_id) review_id, assigned_dept, confidence
                 FROM reviews_assigned ORDER BY review_id, created_at DESC
-            ) rvs USING (review_id)
+            ) rvs ON rvs.review_id = rmi.review_id
             WHERE rmi.processing_status = 'ANALYZED'
               AND DATE_TRUNC('day', rmi.review_created_at)::date = :target_date
             ON CONFLICT (review_id, date)

--- a/src/loaders/batch_loader.py
+++ b/src/loaders/batch_loader.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Dict, Optional, Set
 from uuid import UUID
 
-import pyarrow.parquet as pq
+from sqlalchemy import text
 from sqlalchemy.exc import PendingRollbackError
 
 from src.utils.db_connector import DatabaseConnector
@@ -121,18 +121,14 @@ class BatchLoader:
             f"(retry={batch.retry_count})"
         )
 
-        # 1. MinIO에서 Parquet 읽기
-        if _is_local_storage_path(batch.storage_path):
-            table = pq.read_table(batch.storage_path)
-        else:
-            if getattr(self, "_minio", None) is None:
-                self._minio = MinIOClient()
-            table = self._minio.get_parquet(_object_key_from_storage_path(batch.storage_path))
+        # 1. Parquet 읽기: 로컬 파일, s3:// URI, MinIO object key를 모두 지원한다.
+        table = self._read_batch_table(batch.storage_path)
         data_dicts = table.to_pylist()
         records = [AppReviewSchema(**d) for d in data_dicts]
         if not records:
             self.logger.warning(f"Batch {batch.batch_id}: empty Parquet file")
             batch.status = IngestionBatchStatusType.LOADED
+            batch.error_message = None
             batch.loaded_at = datetime.now(timezone.utc)
             batch.updated_at = datetime.now(timezone.utc)
             session.commit()
@@ -160,6 +156,7 @@ class BatchLoader:
         if not new_records:
             self.logger.info(f"Batch {batch.batch_id}: all records already loaded (idempotent)")
             batch.status = IngestionBatchStatusType.LOADED
+            batch.error_message = None
             batch.loaded_at = datetime.now(timezone.utc)
             batch.updated_at = datetime.now(timezone.utc)
             session.commit()
@@ -169,6 +166,7 @@ class BatchLoader:
         now = datetime.now(timezone.utc)
         service_id_cache: Dict[UUID, Optional[UUID]] = {}
         master_index_records = []
+        app_review_rows = []
         for record in new_records:
             app_uuid = UUID(record.app_id)
             self._ensure_app_exists(session, app_uuid, record, batch, platform_type)
@@ -191,10 +189,43 @@ class BatchLoader:
                 retry_count=0
             )
             master_index_records.append(master_index)
+            app_review_rows.append(
+                {
+                    "review_id": UUID(record.review_id),
+                    "app_id": app_uuid,
+                    "platform_type": platform_type.value,
+                    "platform_review_id": record.platform_review_id,
+                    "reviewer_name": record.reviewer_name,
+                    "review_text": record.review_text,
+                    "rating": record.rating,
+                    "reviewed_at": record.reviewed_at,
+                    "is_reply": record.is_reply or False,
+                    "reply_comment": record.reply_comment,
+                }
+            )
 
         # 4. DB 적재 + 배치 상태 업데이트
         session.add_all(master_index_records)
+        if app_review_rows:
+            session.execute(
+                text(
+                    """
+                    INSERT INTO app_reviews (
+                        review_id, app_id, platform_type, country_code,
+                        platform_review_id, reviewer_name, review_text, rating,
+                        app_version, reviewed_at, is_reply, reply_comment
+                    )
+                    VALUES (
+                        :review_id, :app_id, :platform_type, 'kr',
+                        :platform_review_id, :reviewer_name, :review_text, :rating,
+                        NULL, :reviewed_at, :is_reply, :reply_comment
+                    )
+                    """
+                ),
+                app_review_rows,
+            )
         batch.status = IngestionBatchStatusType.LOADED
+        batch.error_message = None
         batch.loaded_at = now
         batch.updated_at = now
         session.commit()

--- a/src/loaders/batch_loader.py
+++ b/src/loaders/batch_loader.py
@@ -241,9 +241,7 @@ class BatchLoader:
             self._minio = None
 
         if storage_path.startswith(("s3://", "minio://")):
-            key = storage_path.split("://", 1)[1]
-            if "/" in key:
-                key = key.split("/", 1)[1]
+            key = _object_key_from_storage_path(storage_path)
             if self._minio is None:
                 self._minio = MinIOClient()
             return self._minio.get_parquet(key)
@@ -326,6 +324,13 @@ class BatchLoader:
         if not missing_ids:
             return
 
+        if batch.platform_app_id == "daily_batch":
+            missing = ", ".join(str(app_id) for app_id in sorted(missing_ids, key=str))
+            raise ValueError(
+                "Daily batch requires app seed rows before loading; "
+                f"missing app_id(s): {missing}"
+            )
+
         for app_id in missing_ids:
             session.add(
                 App(
@@ -354,5 +359,10 @@ def _is_local_storage_path(storage_path: str) -> bool:
 
 def _object_key_from_storage_path(storage_path: str) -> str:
     if storage_path.startswith("s3://"):
-        return storage_path.removeprefix("s3://").split("/", 1)[1]
+        path_without_scheme = storage_path.removeprefix("s3://")
+        if "/" not in path_without_scheme:
+            raise ValueError(f"s3 storage path must include bucket and key: {storage_path}")
+        return path_without_scheme.split("/", 1)[1]
+    if storage_path.startswith("minio://"):
+        return storage_path.removeprefix("minio://")
     return storage_path

--- a/src/loaders/batch_loader.py
+++ b/src/loaders/batch_loader.py
@@ -5,13 +5,18 @@ Parquet 파일을 읽고 ReviewMasterIndex에 적재합니다.
 """
 
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Dict, Optional, Set
 from uuid import UUID
+
+import pyarrow.parquet as pq
+from sqlalchemy.exc import PendingRollbackError
 
 from src.utils.db_connector import DatabaseConnector
 from src.utils.logger import get_logger
 from src.utils.minio_client import MinIOClient
 from src.models.app_metadata import AppMetadata
+from src.models.apps import App
 from src.models.ingestion_batch import IngestionBatch
 from src.models.review_master_index import ReviewMasterIndex
 from src.models.enums import IngestionBatchStatusType, PlatformType, ProcessingStatusType
@@ -33,6 +38,7 @@ class BatchLoader:
             총 적재된 배치 수
         """
         session = self.db_connector.get_session()
+        should_close_session = bool(session.info.get("owned_by_db_connector"))
         try:
             pending_batches = (
                 session.query(IngestionBatch)
@@ -56,19 +62,53 @@ class BatchLoader:
             loaded = 0
 
             for batch in pending_batches:
+                batch_snapshot = {
+                    "batch_id": batch.batch_id,
+                    "source_type": batch.source_type,
+                    "platform_app_id": batch.platform_app_id,
+                    "app_name": batch.app_name,
+                    "storage_path": batch.storage_path,
+                    "file_format": batch.file_format,
+                    "record_count": batch.record_count,
+                    "retry_count": batch.retry_count,
+                    "max_retries": batch.max_retries,
+                    "created_at": batch.created_at,
+                }
                 try:
                     self._load_single_batch(session, batch)
                     loaded += 1
                 except Exception as e:
-                    session.rollback()
-                    self.logger.error(f"Failed to load batch {batch.batch_id}: {e}")
+                    self.logger.error(f"Failed to load batch {batch_snapshot['batch_id']}: {e}")
+                    try:
+                        batch = session.get(IngestionBatch, batch_snapshot["batch_id"])
+                    except PendingRollbackError:
+                        session.rollback()
+                        batch = session.get(IngestionBatch, batch_snapshot["batch_id"])
+                    if batch is None:
+                        batch = IngestionBatch(
+                            batch_id=batch_snapshot["batch_id"],
+                            source_type=batch_snapshot["source_type"],
+                            platform_app_id=batch_snapshot["platform_app_id"],
+                            app_name=batch_snapshot["app_name"],
+                            storage_path=batch_snapshot["storage_path"],
+                            file_format=batch_snapshot["file_format"],
+                            record_count=batch_snapshot["record_count"],
+                            status=IngestionBatchStatusType.PENDING,
+                            retry_count=batch_snapshot["retry_count"],
+                            max_retries=batch_snapshot["max_retries"],
+                            created_at=batch_snapshot["created_at"],
+                            updated_at=datetime.now(timezone.utc),
+                        )
+                        session.add(batch)
+                        session.flush()
                     self._mark_batch_failed(session, batch, str(e))
 
             self.logger.info(f"Loaded {loaded}/{len(pending_batches)} batches")
             return loaded
 
         finally:
-            session.close()
+            if should_close_session:
+                session.close()
 
     def _load_single_batch(self, session, batch: IngestionBatch) -> int:
         """단일 배치 처리: Parquet 읽기 → ReviewMasterIndex 적재.
@@ -82,9 +122,12 @@ class BatchLoader:
         )
 
         # 1. MinIO에서 Parquet 읽기
-        if self._minio is None:
-            self._minio = MinIOClient()
-        table = self._minio.get_parquet(batch.storage_path)
+        if _is_local_storage_path(batch.storage_path):
+            table = pq.read_table(batch.storage_path)
+        else:
+            if getattr(self, "_minio", None) is None:
+                self._minio = MinIOClient()
+            table = self._minio.get_parquet(_object_key_from_storage_path(batch.storage_path))
         data_dicts = table.to_pylist()
         records = [AppReviewSchema(**d) for d in data_dicts]
         if not records:
@@ -106,6 +149,7 @@ class BatchLoader:
             except ValueError:
                 self.logger.warning(f"Skipping record with invalid app_id UUID: {r.app_id}")
         records = valid_records
+        self._ensure_apps_exist(session, records, batch)
 
         existing_ids: Set[str] = set()
         for app_uuid in app_uuids_in_batch:
@@ -127,6 +171,7 @@ class BatchLoader:
         master_index_records = []
         for record in new_records:
             app_uuid = UUID(record.app_id)
+            self._ensure_app_exists(session, app_uuid, record, batch, platform_type)
             if app_uuid not in service_id_cache:
                 service_id_cache[app_uuid] = self._get_service_id(session, app_uuid)
             master_index = ReviewMasterIndex(
@@ -159,6 +204,51 @@ class BatchLoader:
         )
         return len(master_index_records)
 
+    def _read_batch_table(self, storage_path: str):
+        """Read a Parquet batch from local path or MinIO/S3 storage."""
+        if not hasattr(self, "_minio"):
+            self._minio = None
+
+        if storage_path.startswith(("s3://", "minio://")):
+            key = storage_path.split("://", 1)[1]
+            if "/" in key:
+                key = key.split("/", 1)[1]
+            if self._minio is None:
+                self._minio = MinIOClient()
+            return self._minio.get_parquet(key)
+
+        from pathlib import Path
+        import pyarrow.parquet as pq
+
+        local_path = Path(storage_path)
+        if local_path.exists():
+            return pq.read_table(local_path)
+        if self._minio is None:
+            self._minio = MinIOClient()
+        return self._minio.get_parquet(storage_path)
+
+    def _ensure_app_exists(
+        self,
+        session,
+        app_uuid: UUID,
+        record: AppReviewSchema,
+        batch: IngestionBatch,
+        platform_type: PlatformType,
+    ) -> None:
+        """Ensure FK target exists for ReviewMasterIndex rows."""
+        if session.get(App, app_uuid) is not None:
+            return
+
+        session.add(
+            App(
+                app_id=app_uuid,
+                platform_app_id=batch.platform_app_id,
+                platform_type=platform_type,
+                name=batch.app_name or f"app_{record.app_id}",
+            )
+        )
+        session.flush()
+
     def _mark_batch_failed(self, session, batch: IngestionBatch, error_msg: str) -> None:
         """배치 실패 처리: retry_count 증가, max_retries 도달 시 DEAD_LETTER."""
         batch.retry_count += 1
@@ -183,13 +273,38 @@ class BatchLoader:
         """app_metadata에서 현재 유효한 service_id 조회."""
         row = (
             session.query(AppMetadata.service_id)
-            .filter(AppMetadata.app_id == app_id, AppMetadata.is_active == True)
+            .filter(AppMetadata.app_id == app_id, AppMetadata.is_active.is_(True))
             .order_by(AppMetadata.valid_from.desc())
             .first()
         )
         if row is None:
             self.logger.warning(f"No active app_metadata found for app_id={app_id}")
         return row.service_id if row else None
+
+    def _ensure_apps_exist(self, session, records: list[AppReviewSchema], batch: IngestionBatch) -> None:
+        """ReviewMasterIndex FK를 만족하도록 배치 레코드의 app row를 보장."""
+        app_ids = {UUID(record.app_id) for record in records}
+        if not app_ids:
+            return
+
+        existing_ids = {
+            row.app_id for row in
+            session.query(App.app_id).filter(App.app_id.in_(app_ids)).all()
+        }
+        missing_ids = app_ids - existing_ids
+        if not missing_ids:
+            return
+
+        for app_id in missing_ids:
+            session.add(
+                App(
+                    app_id=app_id,
+                    platform_app_id=batch.platform_app_id,
+                    platform_type=batch.source_type,
+                    name=batch.app_name or batch.platform_app_id,
+                )
+            )
+        session.flush()
 
     def _get_existing_platform_ids(self, session, app_uuid: UUID, platform_type: PlatformType) -> Set[str]:
         """중복 방지용 기존 platform_review_id 조회."""
@@ -200,3 +315,13 @@ class BatchLoader:
                 platform_type=platform_type
             ).all()
         )
+
+
+def _is_local_storage_path(storage_path: str) -> bool:
+    return "://" not in storage_path or Path(storage_path).is_absolute()
+
+
+def _object_key_from_storage_path(storage_path: str) -> str:
+    if storage_path.startswith("s3://"):
+        return storage_path.removeprefix("s3://").split("/", 1)[1]
+    return storage_path

--- a/src/loaders/batch_loader.py
+++ b/src/loaders/batch_loader.py
@@ -252,6 +252,8 @@ class BatchLoader:
         local_path = Path(storage_path)
         if local_path.exists():
             return pq.read_table(local_path)
+        if local_path.is_absolute():
+            raise FileNotFoundError(f"Parquet file not found: {storage_path}")
         if self._minio is None:
             self._minio = MinIOClient()
         return self._minio.get_parquet(storage_path)

--- a/src/models/app_metadata.py
+++ b/src/models/app_metadata.py
@@ -6,6 +6,7 @@ and tracks historical changes using Slowly Changing Dimension Type 2 pattern.
 
 from sqlalchemy import Column, Integer, Text, Date, Boolean, Enum as SQLEnum, ForeignKey, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
 
 from .base import Base
 from .enums import AppType
@@ -44,6 +45,9 @@ class AppMetadata(Base):
     valid_from = Column(Date, comment='유효 시작일')
     valid_to = Column(Date, comment='유효 종료일 (NULL이면 현재 유효)')
     is_active = Column(Boolean, comment='활성 여부')
+
+    app = relationship('App')
+    service = relationship('AppService')
 
     def __repr__(self):
         return (

--- a/src/models/review.py
+++ b/src/models/review.py
@@ -31,7 +31,7 @@ class Review(Base):
         nullable=False,
         comment='앱 ID (references Parquet, no FK)'
     )
-    platform = Column(
+    platform_type = Column(
         SQLEnum(PlatformType, name='platform_type', create_type=False),
         nullable=False,
         comment='플랫폼 타입 (APPSTORE, PLAYSTORE)'
@@ -75,5 +75,5 @@ class Review(Base):
     def __repr__(self):
         return (
             f"<Review(review_id={self.review_id}, app_id={self.app_id}, "
-            f"platform={self.platform}, rating={self.rating})>"
+            f"platform_type={self.platform_type}, rating={self.rating})>"
         )

--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -47,7 +47,10 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--steps",
         default="crawl,preprocess,features,action,embed",
-        help="Comma-separated steps to run (options: crawl, preprocess, features, action, embed)",
+        help=(
+            "Comma-separated steps to run "
+            "(options: crawl, load, preprocess, features, action, embed, gold, aggregate)"
+        ),
     )
     parser.add_argument("--batch-size", type=int, default=100, help="Batch size for processing steps.")
     parser.add_argument("--limit", type=int, default=None, help="Optional limit for records processed.")

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -362,13 +362,52 @@ class ReviewCleaningPipeline:
                     }
                     for record in preprocessed_records
                 ]
+                review_id_by_platform_review_id: dict[str, UUID] = {}
+                for row in rows:
+                    platform_review_id = row["platform_review_id"]
+                    review_id = row["review_id"]
+                    existing_review_id = review_id_by_platform_review_id.get(platform_review_id)
+                    if existing_review_id is not None and existing_review_id != review_id:
+                        raise ValueError(
+                            "Conflicting review_id values for platform_review_id="
+                            f"{platform_review_id}: {existing_review_id} != {review_id}"
+                        )
+                    review_id_by_platform_review_id[platform_review_id] = review_id
+
+                existing_preprocessed_rows = (
+                    session.query(
+                        ReviewPreprocessed.platform_review_id,
+                        ReviewPreprocessed.review_id,
+                    )
+                    .filter(
+                        ReviewPreprocessed.platform_review_id.in_(
+                            list(review_id_by_platform_review_id)
+                        )
+                    )
+                    .all()
+                )
+                mismatched_rows = [
+                    (
+                        platform_review_id,
+                        stored_review_id,
+                        review_id_by_platform_review_id[platform_review_id],
+                    )
+                    for platform_review_id, stored_review_id in existing_preprocessed_rows
+                    if stored_review_id != review_id_by_platform_review_id[platform_review_id]
+                ]
+                if mismatched_rows:
+                    platform_review_id, stored_review_id, incoming_review_id = mismatched_rows[0]
+                    raise ValueError(
+                        "Existing reviews_preprocessed row has a different review_id for "
+                        f"platform_review_id={platform_review_id}: "
+                        f"{stored_review_id} != {incoming_review_id}"
+                    )
+
                 stmt = insert(ReviewPreprocessed).values(rows)
                 session.execute(
                     stmt.on_conflict_do_update(
                         index_elements=[ReviewPreprocessed.platform_review_id],
                         set_={
-                            "review_id": stmt.excluded.review_id,
-                            "platform_review_id": stmt.excluded.platform_review_id,
                             "refined_text": stmt.excluded.refined_text,
                             "updated_at": func.now(),
                         },

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -3,10 +3,21 @@
 
 Issue #14: Implement Review Data Cleansing Pipeline (Bronze to Silver)
 """
+from collections import defaultdict
+from datetime import date as DateType
+import json
 import re
+import time
+from typing import Any, Dict, List
 import unicodedata
+from uuid import UUID
 
 import emoji
+from flashtext import KeywordProcessor
+import pyarrow as pa
+
+from src.utils.logger import get_logger
+from src.utils.minio_client import MinIOClient
 
 
 # =========================================================
@@ -74,9 +85,6 @@ def mask_pii(text: str) -> str:
 # ReviewCleaner: 8-step 정제 파이프라인 클래스
 # =========================================================
 
-import json
-from flashtext import KeywordProcessor
-
 
 class ReviewCleaner:
     """텍스트 정제 파이프라인 클래스.
@@ -130,16 +138,6 @@ class ReviewCleaner:
 # =========================================================
 # Bronze 로더 / Silver 라이터
 # =========================================================
-
-from datetime import date as DateType
-from collections import defaultdict
-from typing import List, Dict, Any
-import time
-from uuid import UUID
-import pyarrow as pa
-
-from src.utils.logger import get_logger
-from src.utils.minio_client import MinIOClient
 
 logger = get_logger(__name__)
 
@@ -268,7 +266,7 @@ class ReviewCleaningPipeline:
         for app_id, records in groups.items():
             write_silver_parquet(self.minio, app_id, target_date, records)
             logger.info(f"  Wrote {len(records)} rows → Silver (app_id={app_id})")
-            self._update_db_status(review_ids_by_app[app_id])
+            self._update_db_status(review_ids_by_app[app_id], preprocessed_records=records)
 
         elapsed = round(time.time() - start, 2)
         logger.info(
@@ -331,14 +329,21 @@ class ReviewCleaningPipeline:
         finally:
             session.close()
 
-    def _update_db_status(self, review_ids: List[str]) -> None:
-        """ReviewMasterIndex의 처리 상태를 CLEANED로 업데이트한다.
+    def _update_db_status(
+        self,
+        review_ids: List[str],
+        preprocessed_records: List[Dict[str, Any]] | None = None,
+    ) -> None:
+        """reviews_preprocessed 적재 후 ReviewMasterIndex를 CLEANED로 업데이트한다.
 
         정상 RAW row와 이전 cleanse 단계에서 실패했던 row만 성공 처리한다.
         다른 단계의 FAILED row는 이 단계의 성공으로 복구하지 않는다.
         """
+        from sqlalchemy import func
+        from sqlalchemy.dialects.postgresql import insert
         from sqlalchemy import and_, or_
         from src.models.review_master_index import ReviewMasterIndex
+        from src.models.review_preprocessed import ReviewPreprocessed
         from src.models.enums import ProcessingStatusType
 
         if not review_ids:
@@ -348,6 +353,28 @@ class ReviewCleaningPipeline:
 
         session = self.db.get_session()
         try:
+            if preprocessed_records:
+                rows = [
+                    {
+                        "review_id": UUID(str(record["review_id"])),
+                        "platform_review_id": record["platform_review_id"],
+                        "refined_text": record["refined_text"],
+                    }
+                    for record in preprocessed_records
+                ]
+                stmt = insert(ReviewPreprocessed).values(rows)
+                session.execute(
+                    stmt.on_conflict_do_update(
+                        index_elements=[ReviewPreprocessed.platform_review_id],
+                        set_={
+                            "review_id": stmt.excluded.review_id,
+                            "platform_review_id": stmt.excluded.platform_review_id,
+                            "refined_text": stmt.excluded.refined_text,
+                            "updated_at": func.now(),
+                        },
+                    )
+                )
+
             session.query(ReviewMasterIndex).filter(
                 ReviewMasterIndex.review_id.in_(parsed_review_ids),
                 or_(
@@ -366,7 +393,7 @@ class ReviewCleaningPipeline:
             )
             session.commit()
             logger.info(f"  Updated {len(parsed_review_ids)} records to CLEANED")
-        except Exception as e:
+        except Exception:
             session.rollback()
             logger.exception("DB status update failed")
             raise

--- a/src/utils/db_connector.py
+++ b/src/utils/db_connector.py
@@ -8,7 +8,6 @@ import yaml
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-from sqlalchemy.engine.base import Engine
 
 # 이 모듈을 사용하려면 psycopg2-binary가 설치되어 있어야 합니다.
 # pip install psycopg2-binary
@@ -83,7 +82,9 @@ class DatabaseConnector:
 
     def get_session(self):
         """데이터베이스 세션을 반환합니다."""
-        return self.Session()
+        session = self.Session()
+        session.info["owned_by_db_connector"] = True
+        return session
 
     @contextmanager
     def get_autocommit_connection(self):

--- a/src/utils/minio_client.py
+++ b/src/utils/minio_client.py
@@ -37,7 +37,9 @@ class MinIOClient:
         self.endpoint = raw_endpoint or None
         self.access_key = os.environ.get('MINIO_ACCESS_KEY') if access_key is _UNSET else access_key
         self.secret_key = os.environ.get('MINIO_SECRET_KEY') if secret_key is _UNSET else secret_key
-        self.bucket = os.environ['MINIO_BUCKET'] if bucket is _UNSET else bucket
+        self.bucket = os.environ.get('MINIO_BUCKET') if bucket is _UNSET else bucket
+        if not self.bucket:
+            raise ValueError("MINIO_BUCKET must be set or bucket must be provided")
 
         if bool(self.access_key) != bool(self.secret_key):
             raise ValueError(

--- a/src/utils/minio_client.py
+++ b/src/utils/minio_client.py
@@ -11,6 +11,7 @@ import pyarrow.parquet as pq
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
+_UNSET = object()
 
 
 class MinIOClient:
@@ -23,20 +24,20 @@ class MinIOClient:
 
     def __init__(
         self,
-        endpoint: str = None,
-        access_key: str = None,
-        secret_key: str = None,
-        bucket: str = None,
+        endpoint: str | None | object = _UNSET,
+        access_key: str | None | object = _UNSET,
+        secret_key: str | None | object = _UNSET,
+        bucket: str | None | object = _UNSET,
     ):
-        raw_endpoint = endpoint or os.environ.get('MINIO_ENDPOINT', '')
+        raw_endpoint = os.environ.get('MINIO_ENDPOINT', '') if endpoint is _UNSET else (endpoint or '')
         if raw_endpoint and not raw_endpoint.startswith(('http://', 'https://')):
             use_ssl = os.environ.get('MINIO_USE_SSL', 'false').lower() == 'true'
             scheme = 'https' if use_ssl else 'http'
             raw_endpoint = f'{scheme}://{raw_endpoint}'
         self.endpoint = raw_endpoint or None
-        self.access_key = access_key or os.environ.get('MINIO_ACCESS_KEY')
-        self.secret_key = secret_key or os.environ.get('MINIO_SECRET_KEY')
-        self.bucket = bucket or os.environ['MINIO_BUCKET']
+        self.access_key = os.environ.get('MINIO_ACCESS_KEY') if access_key is _UNSET else access_key
+        self.secret_key = os.environ.get('MINIO_SECRET_KEY') if secret_key is _UNSET else secret_key
+        self.bucket = os.environ['MINIO_BUCKET'] if bucket is _UNSET else bucket
 
         if bool(self.access_key) != bool(self.secret_key):
             raise ValueError(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,14 +22,12 @@ import os
 from pathlib import Path
 from datetime import datetime, timezone
 from typing import List, Dict, Any
-from uuid import UUID
 from uuid6 import uuid7
 
-from sqlalchemy import create_engine, text
+from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 from sqlalchemy.pool import NullPool
 
-from src.models.base import Base
 from src.models.apps import App
 from src.models.review_master_index import ReviewMasterIndex
 from src.models.ingestion_batch import IngestionBatch
@@ -50,13 +48,15 @@ def test_db_url() -> str:
        - 서버 개발 시 (VS Code Remote SSH): postgresql://vector_mgr:...@reai.kro.kr:55000/testdb
        - 로컬 개발 시: docker-compose.test.yml 실행 후 localhost:5433/testdb
          (pgvector/pgvector:pg17 이미지 필요: schema_v4.sql의 vector extension 사용)
-    2. Default: postgresql://testuser:testpass@localhost:5433/testdb (docker-compose.test.yml 기본값)
+    2. Default: postgresql://testuser:testpass@localhost:{TEST_POSTGRES_PORT:-5433}/testdb
+       (docker-compose.test.yml 기본값과 동일한 포트)
 
     Note: Tests require a real PostgreSQL database (not SQLite).
     testdb는 프로덕션 DB(postgres)와 완전히 분리된 전용 테스트 DB여야 한다.
     DROP SCHEMA public CASCADE가 실행되므로 절대 프로덕션 DB를 가리켜선 안 된다.
     """
-    default_url = "postgresql://testuser:testpass@localhost:5433/testdb"
+    test_postgres_port = os.getenv("TEST_POSTGRES_PORT", "5433")
+    default_url = f"postgresql://testuser:testpass@localhost:{test_postgres_port}/testdb"
     return os.getenv("TEST_DATABASE_URL", default_url)
 
 
@@ -333,7 +333,7 @@ def db_with_failed_reviews(test_db_session: Session) -> Session:
         ReviewMasterIndex(
             review_id=uuid7(),
             app_id=app.app_id,
-            platform_review_id=f'failed_review_0',
+            platform_review_id='failed_review_0',
             platform_type=PlatformType.APPSTORE,
             review_created_at=now,
             ingested_at=now,
@@ -346,7 +346,7 @@ def db_with_failed_reviews(test_db_session: Session) -> Session:
         ReviewMasterIndex(
             review_id=uuid7(),
             app_id=app.app_id,
-            platform_review_id=f'failed_review_1',
+            platform_review_id='failed_review_1',
             platform_type=PlatformType.APPSTORE,
             review_created_at=now,
             ingested_at=now,
@@ -359,7 +359,7 @@ def db_with_failed_reviews(test_db_session: Session) -> Session:
         ReviewMasterIndex(
             review_id=uuid7(),
             app_id=app.app_id,
-            platform_review_id=f'failed_review_3',
+            platform_review_id='failed_review_3',
             platform_type=PlatformType.APPSTORE,
             review_created_at=now,
             ingested_at=now,

--- a/tests/test_backend_datamart_contract.py
+++ b/tests/test_backend_datamart_contract.py
@@ -1,0 +1,938 @@
+"""Backend-facing Data Mart contract tests.
+
+These tests intentionally use the real PostgreSQL test fixture. They lock the
+schema shape consumed by backend dashboard endpoints without introducing mocks
+or a SQLite fallback.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+from uuid import UUID
+
+import pytest
+from sqlalchemy import text
+from uuid6 import uuid7
+
+
+CONTRACT_DOC_PATH = (
+    Path(__file__).resolve().parents[1] / "docs" / "backend-datamart-contract.md"
+)
+CONTRACT_TABLES = {
+    "fact_service_review_daily": {
+        "columns": {
+            "date": {"data_type": "date", "nullable": False},
+            "service_id": {"data_type": "uuid", "nullable": False},
+            "platform_type": {"data_type": "USER-DEFINED", "nullable": False},
+            "total_review_cnt": {"data_type": "integer", "nullable": True},
+            "action_required_cnt": {"data_type": "integer", "nullable": True},
+            "attention_required_cnt": {"data_type": "integer", "nullable": True},
+            "pos_count": {"data_type": "integer", "nullable": True},
+            "neg_count": {"data_type": "integer", "nullable": True},
+            "avg_rating": {"data_type": "double precision", "nullable": True},
+            "action_ratio": {"data_type": "double precision", "nullable": True},
+        },
+        "primary_key": ["date", "service_id", "platform_type"],
+        "indexes": {"idx_fact_service_review_daily_date"},
+    },
+    "fact_service_aspect_daily": {
+        "columns": {
+            "date": {"data_type": "date", "nullable": False},
+            "service_id": {"data_type": "uuid", "nullable": False},
+            "keyword": {"data_type": "text", "nullable": False},
+            "mention_cnt": {"data_type": "integer", "nullable": True},
+            "avg_sentiment_score": {
+                "data_type": "double precision",
+                "nullable": True,
+            },
+        },
+        "primary_key": ["date", "service_id", "keyword"],
+        "indexes": {"idx_fact_service_aspect_daily_date"},
+    },
+    "fact_category_radar_scores": {
+        "columns": {
+            "date": {"data_type": "date", "nullable": False},
+            "service_id": {"data_type": "uuid", "nullable": False},
+            "category_type": {"data_type": "USER-DEFINED", "nullable": False},
+            "avg_sentiment_score": {
+                "data_type": "double precision",
+                "nullable": True,
+            },
+            "review_cnt": {"data_type": "integer", "nullable": True},
+        },
+        "primary_key": ["date", "service_id", "category_type"],
+        "indexes": {"idx_fact_category_radar_scores_date"},
+    },
+    "srv_daily_review_list": {
+        "columns": {
+            "review_id": {"data_type": "uuid", "nullable": False},
+            "date": {"data_type": "date", "nullable": False},
+            "service_id": {"data_type": "uuid", "nullable": True},
+            "refined_text": {"data_type": "text", "nullable": True},
+            "review_summary": {"data_type": "text", "nullable": True},
+            "rating": {"data_type": "integer", "nullable": True},
+            "reviewed_at": {
+                "data_type": "timestamp with time zone",
+                "nullable": True,
+            },
+            "sentiment_score": {"data_type": "double precision", "nullable": True},
+            "is_action_required": {"data_type": "boolean", "nullable": True},
+            "is_attention_required": {"data_type": "boolean", "nullable": True},
+            "assigned_dept": {"data_type": "ARRAY", "nullable": True},
+            "keyword": {"data_type": "ARRAY", "nullable": True},
+            "confidence": {"data_type": "double precision", "nullable": True},
+        },
+        "primary_key": ["review_id", "date"],
+        "indexes": {
+            "idx_srv_daily_review_list_service_id",
+            "idx_srv_daily_review_list_date",
+            "idx_srv_daily_review_list_is_action_required",
+            "idx_srv_daily_review_list_keyword",
+        },
+    },
+}
+
+SERVICE_FK_TABLES = set(CONTRACT_TABLES)
+CONTRACT_TARGET_DATE = date(2026, 5, 2)
+CONTRACT_PARTITION_NAME = "srv_daily_review_list_contract_2026_05_02"
+READINESS_TARGET_DATE = date(2026, 5, 3)
+READINESS_PARTITION_NAME = "srv_daily_review_list_2026_05_03"
+CONTRACT_DOC_MARKERS = {
+    "## Contract boundary": "contract table list",
+    "## Column contract matrices": "column contract section",
+    "Date/timezone semantics": "date/timezone semantics",
+    "Nullable `srv_daily_review_list.service_id`": "nullable service_id handling",
+    "TTL/partition retention": "TTL/partition retention",
+    "Breaking-change policy": "breaking-change policy",
+    "Docker validation and verification commands": "Docker validation",
+    "Backend query examples": "backend query examples",
+    "Service summary dashboard": "summary dashboard query",
+    "Keyword/aspect trend": "aspect trend query",
+    "Radar chart": "radar chart query",
+    "Review list with stable pagination order": "review list query",
+    "Current serving indexes support service, date, action-required, and keyword filtering": (
+        "pagination index limitation"
+    ),
+    "## Serving readiness proof": "production-like serving readiness proof",
+    "## Manual live crawl smoke proof": "manual live crawl smoke proof",
+}
+
+
+@pytest.mark.requires_db
+def test_backend_datamart_columns_match_contract(test_db_session):
+    """Backend DTO fields must exist with stable PostgreSQL types/nullability."""
+    result = test_db_session.execute(
+        text(
+            """
+            SELECT table_name, column_name, data_type, is_nullable
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name IN :table_names
+            """
+        ),
+        {"table_names": tuple(CONTRACT_TABLES)},
+    )
+
+    actual_columns = {
+        (row.table_name, row.column_name): {
+            "data_type": row.data_type,
+            "nullable": row.is_nullable == "YES",
+        }
+        for row in result
+    }
+
+    for table_name, contract in CONTRACT_TABLES.items():
+        for column_name, expected in contract["columns"].items():
+            actual = actual_columns.get((table_name, column_name))
+            assert actual is not None, f"{table_name}.{column_name} is missing"
+            assert actual["data_type"] == expected["data_type"], (
+                f"{table_name}.{column_name} type mismatch: "
+                f"expected {expected['data_type']}, got {actual['data_type']}"
+            )
+            assert actual["nullable"] is expected["nullable"], (
+                f"{table_name}.{column_name} nullability mismatch: "
+                f"expected nullable={expected['nullable']}, "
+                f"got nullable={actual['nullable']}"
+            )
+
+
+def test_backend_datamart_contract_doc_is_complete():
+    """The backend handoff doc must cover required contract and query topics."""
+    contract_doc = CONTRACT_DOC_PATH.read_text(encoding="utf-8")
+
+    for table_name in CONTRACT_TABLES:
+        assert table_name in contract_doc
+
+    for marker, description in CONTRACT_DOC_MARKERS.items():
+        assert marker in contract_doc, f"Missing {description}: {marker}"
+
+    assert "Removes, renames, or repurposes a contract table" in contract_doc
+    assert "Removes, renames, or repurposes a contract column" in contract_doc
+    assert "Changes PostgreSQL type, enum domain, nullability, primary key" in contract_doc
+    assert "Alembic revision" in contract_doc
+    assert "migration impact" in contract_doc
+    assert "service_id = :service_id" in contract_doc
+    assert "exclude rows where `service_id IS NULL`" in contract_doc
+    assert "Backend API endpoints" in contract_doc
+    assert "New `fact_*`, `dim_*`, `srv_*`, view, or materialized-view tables" in contract_doc
+
+
+@pytest.mark.requires_db
+def test_backend_datamart_primary_keys_match_contract(test_db_session):
+    """Upserts and cursor-style backend reads depend on deterministic keys."""
+    for table_name, contract in CONTRACT_TABLES.items():
+        result = test_db_session.execute(
+            text(
+                """
+                SELECT attribute.attname
+                FROM pg_index index
+                JOIN pg_class table_class
+                  ON table_class.oid = index.indrelid
+                JOIN pg_namespace namespace
+                  ON namespace.oid = table_class.relnamespace
+                CROSS JOIN LATERAL unnest(index.indkey)
+                  WITH ORDINALITY AS key_columns(attnum, ordinal)
+                JOIN pg_attribute attribute
+                  ON attribute.attrelid = table_class.oid
+                 AND attribute.attnum = key_columns.attnum
+                WHERE namespace.nspname = 'public'
+                  AND table_class.relname = :table_name
+                  AND index.indisprimary
+                ORDER BY key_columns.ordinal
+                """
+            ),
+            {"table_name": table_name},
+        )
+
+        actual_key = [row.attname for row in result]
+        assert actual_key == contract["primary_key"], (
+            f"{table_name} primary key mismatch: "
+            f"expected {contract['primary_key']}, got {actual_key}"
+        )
+
+
+@pytest.mark.requires_db
+def test_backend_datamart_indexes_and_foreign_keys_are_query_ready(test_db_session):
+    """Dashboard filters need service/date/action indexes and app_service FKs."""
+    index_rows = test_db_session.execute(
+        text(
+            """
+            SELECT tablename, indexname
+            FROM pg_indexes
+            WHERE schemaname = 'public'
+              AND tablename IN :table_names
+            """
+        ),
+        {"table_names": tuple(CONTRACT_TABLES)},
+    )
+    indexes_by_table: dict[str, set[str]] = {}
+    for row in index_rows:
+        indexes_by_table.setdefault(row.tablename, set()).add(row.indexname)
+
+    for table_name, contract in CONTRACT_TABLES.items():
+        missing_indexes = contract["indexes"] - indexes_by_table.get(table_name, set())
+        assert not missing_indexes, f"{table_name} missing indexes: {missing_indexes}"
+
+    fk_rows = test_db_session.execute(
+        text(
+            """
+            SELECT
+                source.relname AS table_name,
+                target.relname AS referred_table,
+                delete_rule.confdeltype AS delete_rule
+            FROM pg_constraint delete_rule
+            JOIN pg_class source
+              ON source.oid = delete_rule.conrelid
+            JOIN pg_class target
+              ON target.oid = delete_rule.confrelid
+            JOIN pg_namespace namespace
+              ON namespace.oid = source.relnamespace
+            WHERE namespace.nspname = 'public'
+              AND delete_rule.contype = 'f'
+              AND source.relname IN :table_names
+            """
+        ),
+        {"table_names": tuple(SERVICE_FK_TABLES)},
+    )
+    service_fk_tables = {
+        row.table_name
+        for row in fk_rows
+        if row.referred_table == "app_service" and row.delete_rule == "c"
+    }
+    assert service_fk_tables == SERVICE_FK_TABLES
+
+
+@pytest.mark.requires_db
+def test_backend_datamart_review_list_is_range_partitioned(test_db_session):
+    """The hot review-list table must remain range-partitioned by date."""
+    row = test_db_session.execute(
+        text(
+            """
+            SELECT table_class.relkind, partitioned.partstrat
+            FROM pg_class table_class
+            JOIN pg_namespace namespace
+              ON namespace.oid = table_class.relnamespace
+            JOIN pg_partitioned_table partitioned
+              ON partitioned.partrelid = table_class.oid
+            WHERE namespace.nspname = 'public'
+              AND table_class.relname = 'srv_daily_review_list'
+            """
+        )
+    ).one()
+
+    assert row.relkind == "p"
+    assert row.partstrat == "r"
+
+
+@pytest.mark.requires_db
+def test_backend_datamart_accepts_backend_dashboard_read_shapes(test_db_session):
+    """Insert contract rows and prove backend-style queries work on PostgreSQL."""
+    service_id = uuid7()
+    review_id = uuid7()
+    _create_contract_partition(test_db_session)
+    _insert_contract_rows(test_db_session, service_id, review_id)
+
+    summary_row = test_db_session.execute(
+        text(
+            """
+            SELECT
+                total_review_cnt,
+                action_required_cnt,
+                attention_required_cnt,
+                avg_rating,
+                action_ratio
+            FROM fact_service_review_daily
+            WHERE service_id = :service_id
+              AND date = :target_date
+              AND platform_type = 'APPSTORE'
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    ).one()
+    assert summary_row.total_review_cnt == 3
+    assert summary_row.action_required_cnt == 1
+    assert summary_row.attention_required_cnt == 2
+    assert summary_row.avg_rating == 4.25
+    assert summary_row.action_ratio == 0.3333
+
+    aspect_row = test_db_session.execute(
+        text(
+            """
+            SELECT keyword, mention_cnt, avg_sentiment_score
+            FROM fact_service_aspect_daily
+            WHERE service_id = :service_id
+              AND date = :target_date
+            ORDER BY mention_cnt DESC
+            LIMIT 1
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    ).one()
+    assert aspect_row.keyword == "login"
+    assert aspect_row.mention_cnt == 2
+    assert aspect_row.avg_sentiment_score == 0.75
+
+    radar_row = test_db_session.execute(
+        text(
+            """
+            SELECT category_type::text, avg_sentiment_score, review_cnt
+            FROM fact_category_radar_scores
+            WHERE service_id = :service_id
+              AND date = :target_date
+              AND category_type = 'USABILITY'
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    ).one()
+    assert radar_row.category_type == "USABILITY"
+    assert radar_row.avg_sentiment_score == 0.82
+    assert radar_row.review_cnt == 3
+
+    review_row = test_db_session.execute(
+        text(
+            """
+            SELECT
+                review_id,
+                review_summary,
+                rating,
+                sentiment_score,
+                assigned_dept,
+                keyword,
+                confidence
+            FROM srv_daily_review_list
+            WHERE service_id = :service_id
+              AND date = :target_date
+              AND is_action_required IS TRUE
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    ).one()
+    assert UUID(str(review_row.review_id)) == review_id
+    assert review_row.review_summary == "Login flow needs attention"
+    assert review_row.rating == 2
+    assert review_row.sentiment_score == 0.25
+    assert review_row.assigned_dept == ["CX", "APP"]
+    assert review_row.keyword == ["login", "error"]
+    assert review_row.confidence == 0.91
+
+
+@pytest.mark.requires_db
+def test_backend_datamart_readiness_step_generates_semantic_rows(
+    test_db_engine,
+    test_db_url,
+    monkeypatch,
+):
+    """The real aggregate step must populate all backend-facing mart tables."""
+    from src.pipeline.steps import run_steps
+
+    service_id = uuid7()
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = f"readiness-{review_id}"
+
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    _cleanup_readiness_probe(
+        test_db_engine,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    try:
+        with test_db_engine.begin() as connection:
+            _insert_readiness_upstream_rows(
+                connection,
+                service_id=service_id,
+                app_id=app_id,
+                review_id=review_id,
+                platform_review_id=platform_review_id,
+            )
+
+        results = run_steps(["aggregate"], target_date=str(READINESS_TARGET_DATE))
+
+        assert len(results) == 1
+        aggregate_result = results[0]
+        assert aggregate_result.step == "aggregate"
+        assert aggregate_result.status == "success", aggregate_result.message
+        assert aggregate_result.as_dict()["validations"] is None
+
+        with test_db_engine.connect() as connection:
+            summary_row = connection.execute(
+                text(
+                    """
+                    SELECT
+                        total_review_cnt,
+                        action_required_cnt,
+                        attention_required_cnt,
+                        pos_count,
+                        neg_count,
+                        avg_rating,
+                        action_ratio
+                    FROM fact_service_review_daily
+                    WHERE service_id = :service_id
+                      AND date = :target_date
+                      AND platform_type = 'APPSTORE'
+                    """
+                ),
+                {"service_id": service_id, "target_date": READINESS_TARGET_DATE},
+            ).one()
+            assert summary_row.total_review_cnt == 1
+            assert summary_row.action_required_cnt == 1
+            assert summary_row.attention_required_cnt == 1
+            assert summary_row.pos_count == 1
+            assert summary_row.neg_count == 0
+            assert summary_row.avg_rating == 2
+            assert summary_row.action_ratio == 1.0
+
+            aspect_rows = connection.execute(
+                text(
+                    """
+                    SELECT keyword, mention_cnt, avg_sentiment_score
+                    FROM fact_service_aspect_daily
+                    WHERE service_id = :service_id
+                      AND date = :target_date
+                    ORDER BY keyword ASC
+                    """
+                ),
+                {"service_id": service_id, "target_date": READINESS_TARGET_DATE},
+            ).mappings().all()
+            aspect_values = [dict(row) for row in aspect_rows]
+            assert aspect_values == [
+                {
+                    "keyword": "login",
+                    "mention_cnt": 1,
+                    "avg_sentiment_score": 0.25,
+                },
+                {
+                    "keyword": "speed",
+                    "mention_cnt": 1,
+                    "avg_sentiment_score": 0.75,
+                },
+            ]
+
+            radar_rows = connection.execute(
+                text(
+                    """
+                    SELECT category_type::text, avg_sentiment_score, review_cnt
+                    FROM fact_category_radar_scores
+                    WHERE service_id = :service_id
+                      AND date = :target_date
+                    ORDER BY category_type ASC
+                    """
+                ),
+                {"service_id": service_id, "target_date": READINESS_TARGET_DATE},
+            ).all()
+            assert [(row.category_type, row.avg_sentiment_score, row.review_cnt) for row in radar_rows] == [
+                ("SPEED", 0.75, 1),
+                ("USABILITY", 0.25, 1),
+            ]
+
+            review_row = connection.execute(
+                text(
+                    """
+                    SELECT
+                        review_id,
+                        refined_text,
+                        review_summary,
+                        rating,
+                        sentiment_score,
+                        is_action_required,
+                        is_attention_required,
+                        assigned_dept,
+                        keyword,
+                        confidence
+                    FROM srv_daily_review_list
+                    WHERE service_id = :service_id
+                      AND date = :target_date
+                    """
+                ),
+                {"service_id": service_id, "target_date": READINESS_TARGET_DATE},
+            ).one()
+            assert UUID(str(review_row.review_id)) == review_id
+            assert review_row.refined_text == "login is broken and slow"
+            assert review_row.review_summary == "Login flow is broken and slow"
+            assert review_row.rating == 2
+            assert review_row.sentiment_score == 0.5
+            assert review_row.is_action_required is True
+            assert review_row.is_attention_required is True
+            assert review_row.assigned_dept == ["CX", "APP"]
+            assert set(review_row.keyword) == {"login", "speed"}
+            assert review_row.confidence == 0.88
+    finally:
+        _cleanup_readiness_probe(
+            test_db_engine,
+            service_id=service_id,
+            app_id=app_id,
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+        )
+
+
+def _create_contract_partition(test_db_session) -> None:
+    test_db_session.execute(
+        text(
+            f"""
+            CREATE TABLE IF NOT EXISTS public.{CONTRACT_PARTITION_NAME}
+            PARTITION OF public.srv_daily_review_list
+            FOR VALUES FROM ('2026-05-02') TO ('2026-05-03')
+            """
+        )
+    )
+
+
+def _insert_contract_rows(test_db_session, service_id, review_id) -> None:
+    reviewed_at = datetime(2026, 5, 2, 9, 30, tzinfo=timezone.utc)
+    test_db_session.execute(
+        text(
+            """
+            INSERT INTO app_service (service_id, service_name)
+            VALUES (:service_id, 'Contract Banking')
+            """
+        ),
+        {"service_id": service_id},
+    )
+    test_db_session.execute(
+        text(
+            """
+            INSERT INTO fact_service_review_daily (
+                date,
+                service_id,
+                platform_type,
+                total_review_cnt,
+                action_required_cnt,
+                attention_required_cnt,
+                avg_rating,
+                pos_count,
+                neg_count,
+                action_ratio
+            )
+            VALUES (
+                :target_date,
+                :service_id,
+                'APPSTORE',
+                3,
+                1,
+                2,
+                4.25,
+                2,
+                1,
+                0.3333
+            )
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    )
+    test_db_session.execute(
+        text(
+            """
+            INSERT INTO fact_service_aspect_daily (
+                date,
+                service_id,
+                keyword,
+                mention_cnt,
+                avg_sentiment_score
+            )
+            VALUES (:target_date, :service_id, 'login', 2, 0.75)
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    )
+    test_db_session.execute(
+        text(
+            """
+            INSERT INTO fact_category_radar_scores (
+                date,
+                service_id,
+                category_type,
+                avg_sentiment_score,
+                review_cnt
+            )
+            VALUES (:target_date, :service_id, 'USABILITY', 0.82, 3)
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    )
+    test_db_session.execute(
+        text(
+            """
+            INSERT INTO srv_daily_review_list (
+                review_id,
+                date,
+                service_id,
+                refined_text,
+                review_summary,
+                rating,
+                reviewed_at,
+                sentiment_score,
+                is_action_required,
+                is_attention_required,
+                assigned_dept,
+                keyword,
+                confidence
+            )
+            VALUES (
+                :review_id,
+                :target_date,
+                :service_id,
+                'login error after update',
+                'Login flow needs attention',
+                2,
+                :reviewed_at,
+                0.25,
+                TRUE,
+                TRUE,
+                ARRAY['CX', 'APP'],
+                ARRAY['login', 'error'],
+                0.91
+            )
+            """
+        ),
+        {
+            "review_id": review_id,
+            "service_id": service_id,
+            "target_date": CONTRACT_TARGET_DATE,
+            "reviewed_at": reviewed_at,
+        },
+    )
+
+
+def _insert_readiness_upstream_rows(
+    connection,
+    *,
+    service_id,
+    app_id,
+    review_id,
+    platform_review_id: str,
+) -> None:
+    reviewed_at = datetime(2026, 5, 3, 9, 30, tzinfo=timezone.utc)
+    connection.execute(
+        text(
+            """
+            INSERT INTO app_service (service_id, service_name)
+            VALUES (:service_id, 'Readiness Banking')
+            """
+        ),
+        {"service_id": service_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO apps (app_id, platform_app_id, platform_type, name)
+            VALUES (:app_id, 'readiness.appstore', 'APPSTORE', 'Readiness App')
+            """
+        ),
+        {"app_id": app_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO review_master_index (
+                review_id,
+                app_id,
+                service_id,
+                platform_review_id,
+                platform_type,
+                review_created_at,
+                ingested_at,
+                processing_status,
+                parquet_written_at,
+                storage_path,
+                retry_count,
+                is_active,
+                is_reply
+            )
+            VALUES (
+                :review_id,
+                :app_id,
+                :service_id,
+                :platform_review_id,
+                'APPSTORE',
+                :reviewed_at,
+                :reviewed_at,
+                'ANALYZED',
+                :reviewed_at,
+                's3://reai-data/bronze/readiness/review.parquet',
+                0,
+                TRUE,
+                FALSE
+            )
+            """
+        ),
+        {
+            "review_id": review_id,
+            "app_id": app_id,
+            "service_id": service_id,
+            "platform_review_id": platform_review_id,
+            "reviewed_at": reviewed_at,
+        },
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO app_reviews (
+                review_id,
+                app_id,
+                platform_type,
+                country_code,
+                platform_review_id,
+                reviewer_name,
+                review_text,
+                rating,
+                app_version,
+                reviewed_at,
+                is_reply,
+                reply_comment
+            )
+            VALUES (
+                :review_id,
+                :app_id,
+                'APPSTORE',
+                'kr',
+                :platform_review_id,
+                'readiness-reviewer',
+                'login is broken and slow',
+                2,
+                '1.0.0',
+                :reviewed_at,
+                FALSE,
+                NULL
+            )
+            """
+        ),
+        {
+            "review_id": review_id,
+            "app_id": app_id,
+            "platform_review_id": platform_review_id,
+            "reviewed_at": reviewed_at,
+        },
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO reviews_preprocessed (
+                review_id,
+                app_review_id,
+                platform_review_id,
+                refined_text
+            )
+            VALUES (
+                :review_id,
+                :review_id,
+                :platform_review_id,
+                'login is broken and slow'
+            )
+            """
+        ),
+        {"review_id": review_id, "platform_review_id": platform_review_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO review_action_analysis (
+                review_id,
+                is_action_required,
+                action_confidence_score,
+                trigger_reason,
+                is_attention_required,
+                is_verified,
+                analyzed_at,
+                review_summary
+            )
+            VALUES (
+                :review_id,
+                TRUE,
+                0.93,
+                'login failure',
+                TRUE,
+                TRUE,
+                :reviewed_at,
+                'Login flow is broken and slow'
+            )
+            """
+        ),
+        {"review_id": review_id, "reviewed_at": reviewed_at},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO review_aspects (
+                review_id,
+                keyword,
+                sentiment_score,
+                category
+            )
+            VALUES
+                (:review_id, 'login', 0.25, 'USABILITY'),
+                (:review_id, 'speed', 0.75, 'SPEED')
+            """
+        ),
+        {"review_id": review_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO reviews_assigned (
+                review_id,
+                assigned_dept,
+                assignment_reason,
+                confidence,
+                is_failed,
+                try_number
+            )
+            VALUES (
+                :review_id,
+                ARRAY['CX', 'APP'],
+                'readiness semantic route',
+                0.88,
+                FALSE,
+                1
+            )
+            """
+        ),
+        {"review_id": review_id},
+    )
+
+
+def _cleanup_readiness_probe(
+    test_db_engine,
+    *,
+    service_id,
+    app_id,
+    review_id,
+    platform_review_id: str,
+) -> None:
+    with test_db_engine.begin() as connection:
+        connection.execute(text(f"DROP TABLE IF EXISTS public.{READINESS_PARTITION_NAME}"))
+        connection.execute(
+            text(
+                """
+                DELETE FROM fact_service_review_daily
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                """
+            ),
+            {"service_id": service_id, "target_date": READINESS_TARGET_DATE},
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM fact_service_aspect_daily
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                """
+            ),
+            {"service_id": service_id, "target_date": READINESS_TARGET_DATE},
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM fact_category_radar_scores
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                """
+            ),
+            {"service_id": service_id, "target_date": READINESS_TARGET_DATE},
+        )
+        connection.execute(
+            text("DELETE FROM reviews_assigned WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text("DELETE FROM review_action_analysis WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text("DELETE FROM review_aspects WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text("DELETE FROM reviews_preprocessed WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM app_reviews
+                WHERE review_id = :review_id
+                   OR platform_review_id = :platform_review_id
+                """
+            ),
+            {"review_id": review_id, "platform_review_id": platform_review_id},
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM review_master_index
+                WHERE review_id = :review_id
+                   OR platform_review_id = :platform_review_id
+                """
+            ),
+            {"review_id": review_id, "platform_review_id": platform_review_id},
+        )
+        connection.execute(text("DELETE FROM apps WHERE app_id = :app_id"), {"app_id": app_id})
+        connection.execute(
+            text("DELETE FROM app_service WHERE service_id = :service_id"),
+            {"service_id": service_id},
+        )

--- a/tests/test_backend_datamart_contract.py
+++ b/tests/test_backend_datamart_contract.py
@@ -290,91 +290,95 @@ def test_backend_datamart_accepts_backend_dashboard_read_shapes(test_db_session)
     """Insert contract rows and prove backend-style queries work on PostgreSQL."""
     service_id = uuid7()
     review_id = uuid7()
-    _create_contract_partition(test_db_session)
-    _insert_contract_rows(test_db_session, service_id, review_id)
+    _cleanup_contract_probe(test_db_session, service_id=service_id, review_id=review_id)
+    try:
+        _create_contract_partition(test_db_session)
+        _insert_contract_rows(test_db_session, service_id, review_id)
 
-    summary_row = test_db_session.execute(
-        text(
-            """
-            SELECT
-                total_review_cnt,
-                action_required_cnt,
-                attention_required_cnt,
-                avg_rating,
-                action_ratio
-            FROM fact_service_review_daily
-            WHERE service_id = :service_id
-              AND date = :target_date
-              AND platform_type = 'APPSTORE'
-            """
-        ),
-        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
-    ).one()
-    assert summary_row.total_review_cnt == 3
-    assert summary_row.action_required_cnt == 1
-    assert summary_row.attention_required_cnt == 2
-    assert summary_row.avg_rating == 4.25
-    assert summary_row.action_ratio == 0.3333
+        summary_row = test_db_session.execute(
+            text(
+                """
+                SELECT
+                    total_review_cnt,
+                    action_required_cnt,
+                    attention_required_cnt,
+                    avg_rating,
+                    action_ratio
+                FROM fact_service_review_daily
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                  AND platform_type = 'APPSTORE'
+                """
+            ),
+            {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+        ).one()
+        assert summary_row.total_review_cnt == 3
+        assert summary_row.action_required_cnt == 1
+        assert summary_row.attention_required_cnt == 2
+        assert summary_row.avg_rating == 4.25
+        assert summary_row.action_ratio == 0.3333
 
-    aspect_row = test_db_session.execute(
-        text(
-            """
-            SELECT keyword, mention_cnt, avg_sentiment_score
-            FROM fact_service_aspect_daily
-            WHERE service_id = :service_id
-              AND date = :target_date
-            ORDER BY mention_cnt DESC
-            LIMIT 1
-            """
-        ),
-        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
-    ).one()
-    assert aspect_row.keyword == "login"
-    assert aspect_row.mention_cnt == 2
-    assert aspect_row.avg_sentiment_score == 0.75
+        aspect_row = test_db_session.execute(
+            text(
+                """
+                SELECT keyword, mention_cnt, avg_sentiment_score
+                FROM fact_service_aspect_daily
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                ORDER BY mention_cnt DESC
+                LIMIT 1
+                """
+            ),
+            {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+        ).one()
+        assert aspect_row.keyword == "login"
+        assert aspect_row.mention_cnt == 2
+        assert aspect_row.avg_sentiment_score == 0.75
 
-    radar_row = test_db_session.execute(
-        text(
-            """
-            SELECT category_type::text, avg_sentiment_score, review_cnt
-            FROM fact_category_radar_scores
-            WHERE service_id = :service_id
-              AND date = :target_date
-              AND category_type = 'USABILITY'
-            """
-        ),
-        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
-    ).one()
-    assert radar_row.category_type == "USABILITY"
-    assert radar_row.avg_sentiment_score == 0.82
-    assert radar_row.review_cnt == 3
+        radar_row = test_db_session.execute(
+            text(
+                """
+                SELECT category_type::text, avg_sentiment_score, review_cnt
+                FROM fact_category_radar_scores
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                  AND category_type = 'USABILITY'
+                """
+            ),
+            {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+        ).one()
+        assert radar_row.category_type == "USABILITY"
+        assert radar_row.avg_sentiment_score == 0.82
+        assert radar_row.review_cnt == 3
 
-    review_row = test_db_session.execute(
-        text(
-            """
-            SELECT
-                review_id,
-                review_summary,
-                rating,
-                sentiment_score,
-                assigned_dept,
-                keyword,
-                confidence
-            FROM srv_daily_review_list
-            WHERE service_id = :service_id
-              AND date = :target_date
-              AND is_action_required IS TRUE
-            """
-        ),
-        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
-    ).one()
-    assert UUID(str(review_row.review_id)) == review_id
-    assert review_row.review_summary == "Login flow needs attention"
-    assert review_row.rating == 2
-    assert review_row.sentiment_score == 0.25
-    assert review_row.assigned_dept == ["CX", "APP"]
-    assert review_row.keyword == ["login", "error"]
-    assert review_row.confidence == 0.91
+        review_row = test_db_session.execute(
+            text(
+                """
+                SELECT
+                    review_id,
+                    review_summary,
+                    rating,
+                    sentiment_score,
+                    assigned_dept,
+                    keyword,
+                    confidence
+                FROM srv_daily_review_list
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                  AND is_action_required IS TRUE
+                """
+            ),
+            {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+        ).one()
+        assert UUID(str(review_row.review_id)) == review_id
+        assert review_row.review_summary == "Login flow needs attention"
+        assert review_row.rating == 2
+        assert review_row.sentiment_score == 0.25
+        assert review_row.assigned_dept == ["CX", "APP"]
+        assert review_row.keyword == ["login", "error"]
+        assert review_row.confidence == 0.91
+    finally:
+        _cleanup_contract_probe(test_db_session, service_id=service_id, review_id=review_id)
 
 
 @pytest.mark.requires_db
@@ -539,6 +543,44 @@ def _create_contract_partition(test_db_session) -> None:
             FOR VALUES FROM ('2026-05-02') TO ('2026-05-03')
             """
         )
+    )
+
+
+def _cleanup_contract_probe(test_db_session, *, service_id, review_id) -> None:
+    test_db_session.execute(text(f"DROP TABLE IF EXISTS public.{CONTRACT_PARTITION_NAME}"))
+    test_db_session.execute(
+        text(
+            """
+            DELETE FROM fact_service_review_daily
+            WHERE service_id = :service_id
+              AND date = :target_date
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    )
+    test_db_session.execute(
+        text(
+            """
+            DELETE FROM fact_service_aspect_daily
+            WHERE service_id = :service_id
+              AND date = :target_date
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    )
+    test_db_session.execute(
+        text(
+            """
+            DELETE FROM fact_category_radar_scores
+            WHERE service_id = :service_id
+              AND date = :target_date
+            """
+        ),
+        {"service_id": service_id, "target_date": CONTRACT_TARGET_DATE},
+    )
+    test_db_session.execute(
+        text("DELETE FROM app_service WHERE service_id = :service_id"),
+        {"service_id": service_id},
     )
 
 

--- a/tests/test_backend_datamart_serving_readiness.py
+++ b/tests/test_backend_datamart_serving_readiness.py
@@ -1,0 +1,482 @@
+"""Production-like serving-readiness tests for backend datamarts.
+
+The tests in this module avoid direct inserts into mart tables. They seed the
+upstream pipeline tables, invoke the real pipeline CLI aggregate step, and then
+assert backend-facing mart rows and semantics from PostgreSQL.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import NullPool
+from uuid6 import uuid7
+
+from src.pipeline import cli as pipeline_cli
+
+
+TARGET_DATE = date(2026, 5, 3)
+SERVICE_NAME = "Serving Readiness Bank"
+PLATFORM_REVIEW_PREFIX = "serving-readiness"
+MANUAL_PROOF_DOC = (
+    Path(__file__).resolve().parents[1]
+    / "docs"
+    / "backend-datamart-serving-readiness.md"
+)
+EXPECTED_TABLES = (
+    "fact_service_review_daily",
+    "fact_service_aspect_daily",
+    "fact_category_radar_scores",
+    "srv_daily_review_list",
+)
+
+
+@pytest.mark.requires_db
+def test_backend_datamarts_are_populated_by_real_pipeline_cli_aggregate_step(
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    """Seed analyzed upstream rows, run CLI aggregate, then assert mart output."""
+    engine = create_engine(test_db_url, poolclass=NullPool)
+    SessionLocal = sessionmaker(bind=engine)
+    service_id = uuid7()
+    app_id = uuid7()
+    review_ids = [uuid7(), uuid7(), uuid7()]
+    platform_review_ids = [
+        f"{PLATFORM_REVIEW_PREFIX}-{review_id}" for review_id in review_ids
+    ]
+
+    try:
+        seed_session = SessionLocal()
+        try:
+            _seed_analyzed_pipeline_rows(
+                seed_session,
+                service_id=service_id,
+                app_id=app_id,
+                review_ids=review_ids,
+                platform_review_ids=platform_review_ids,
+            )
+            seed_session.commit()
+        finally:
+            seed_session.close()
+
+        monkeypatch.setenv("DATABASE_URL", test_db_url)
+        assert (
+            pipeline_cli.main(
+                ["--steps", "aggregate", "--target-date", TARGET_DATE.isoformat()]
+            )
+            == 0
+        )
+
+        assert_session = SessionLocal()
+        try:
+            row_counts = _fetch_row_counts(assert_session, service_id)
+            assert row_counts == {
+                "fact_service_review_daily": 1,
+                "fact_service_aspect_daily": 3,
+                "fact_category_radar_scores": 2,
+                "srv_daily_review_list": 3,
+            }
+
+            summary = assert_session.execute(
+                text(
+                    """
+                    SELECT total_review_cnt,
+                           action_required_cnt,
+                           attention_required_cnt,
+                           pos_count,
+                           neg_count,
+                           ROUND(avg_rating::numeric, 4) AS avg_rating,
+                           action_ratio
+                    FROM fact_service_review_daily
+                    WHERE date = :target_date
+                      AND service_id = :service_id
+                      AND platform_type = 'APPSTORE'
+                    """
+                ),
+                {"target_date": TARGET_DATE, "service_id": service_id},
+            ).one()
+            assert summary.total_review_cnt == 3
+            assert summary.action_required_cnt == 2
+            assert summary.attention_required_cnt == 2
+            assert summary.pos_count == 2
+            assert summary.neg_count == 1
+            assert float(summary.avg_rating) == 3.3333
+            assert summary.action_ratio == 0.6667
+
+            top_aspect = assert_session.execute(
+                text(
+                    """
+                    SELECT keyword, mention_cnt, ROUND(avg_sentiment_score::numeric, 4) AS score
+                    FROM fact_service_aspect_daily
+                    WHERE date = :target_date
+                      AND service_id = :service_id
+                    ORDER BY mention_cnt DESC, keyword ASC
+                    LIMIT 1
+                    """
+                ),
+                {"target_date": TARGET_DATE, "service_id": service_id},
+            ).one()
+            assert top_aspect.keyword == "login"
+            assert top_aspect.mention_cnt == 2
+            assert float(top_aspect.score) == 0.4
+
+            radar = assert_session.execute(
+                text(
+                    """
+                    SELECT category_type::text AS category_type,
+                           ROUND(avg_sentiment_score::numeric, 4) AS score,
+                           review_cnt
+                    FROM fact_category_radar_scores
+                    WHERE date = :target_date
+                      AND service_id = :service_id
+                    ORDER BY category_type
+                    """
+                ),
+                {"target_date": TARGET_DATE, "service_id": service_id},
+            ).all()
+            assert [
+                (row.category_type, float(row.score), row.review_cnt)
+                for row in radar
+            ] == [
+                ("SPEED", 0.9, 1),
+                ("USABILITY", 0.4, 2),
+            ]
+
+            action_row = assert_session.execute(
+                text(
+                    """
+                    SELECT review_summary,
+                           rating,
+                           ROUND(sentiment_score::numeric, 4) AS sentiment_score,
+                           is_action_required,
+                           is_attention_required,
+                           assigned_dept,
+                           keyword,
+                           confidence
+                    FROM srv_daily_review_list
+                    WHERE date = :target_date
+                      AND service_id = :service_id
+                      AND is_action_required IS TRUE
+                    ORDER BY reviewed_at
+                    LIMIT 1
+                    """
+                ),
+                {"target_date": TARGET_DATE, "service_id": service_id},
+            ).one()
+            assert action_row.review_summary == "Login failure needs CX follow-up"
+            assert action_row.rating == 1
+            assert float(action_row.sentiment_score) == 0.2
+            assert action_row.is_attention_required is True
+            assert action_row.assigned_dept == ["CX", "APP"]
+            assert action_row.keyword == ["login"]
+            assert action_row.confidence == 0.93
+        finally:
+            assert_session.close()
+    finally:
+        cleanup_session = SessionLocal()
+        try:
+            _cleanup_serving_readiness_rows(
+                cleanup_session,
+                service_id=service_id,
+                app_id=app_id,
+                review_ids=review_ids,
+                platform_review_ids=platform_review_ids,
+            )
+            cleanup_session.commit()
+        finally:
+            cleanup_session.close()
+            engine.dispose()
+
+
+def test_backend_datamart_serving_readiness_manual_smoke_doc_is_actionable():
+    """Manual release proof must document live crawl evidence outside PR CI."""
+    doc = MANUAL_PROOF_DOC.read_text(encoding="utf-8")
+
+    required_markers = [
+        "docker compose up -d",
+        "PYTHONPATH=. uv run python scripts/crawl_reviews.py",
+        "PYTHONPATH=. uv run python scripts/load_reviews.py",
+        "PYTHONPATH=. uv run python scripts/cleanse_reviews.py --date",
+        "PYTHONPATH=. uv run python -m src.pipeline.cli --steps aggregate --target-date",
+        "MinIO",
+        "fact_service_review_daily",
+        "fact_service_aspect_daily",
+        "fact_category_radar_scores",
+        "srv_daily_review_list",
+        "docs/evidence/backend-datamart-serving-readiness",
+        "timestamp",
+        "failures or caveats",
+    ]
+    for marker in required_markers:
+        assert marker in doc
+
+
+def _seed_analyzed_pipeline_rows(
+    session,
+    *,
+    service_id,
+    app_id,
+    review_ids,
+    platform_review_ids,
+) -> None:
+    reviewed_at = [
+        datetime(2026, 5, 3, 9, 0, tzinfo=timezone.utc),
+        datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
+        datetime(2026, 5, 3, 11, 0, tzinfo=timezone.utc),
+    ]
+    session.execute(
+        text(
+            "INSERT INTO app_service (service_id, service_name) "
+            "VALUES (:service_id, :service_name)"
+        ),
+        {"service_id": service_id, "service_name": SERVICE_NAME},
+    )
+    session.execute(
+        text(
+            """
+            INSERT INTO apps (app_id, platform_app_id, platform_type, name)
+            VALUES (:app_id, :platform_app_id, 'APPSTORE', :name)
+            """
+        ),
+        {
+            "app_id": app_id,
+            "platform_app_id": "serving.readiness.appstore",
+            "name": SERVICE_NAME,
+        },
+    )
+
+    for idx, review_id in enumerate(review_ids):
+        session.execute(
+            text(
+                """
+                INSERT INTO review_master_index (
+                    review_id, app_id, service_id, platform_review_id, platform_type,
+                    review_created_at, ingested_at, processing_status,
+                    parquet_written_at, storage_path, retry_count, is_active, is_reply
+                )
+                VALUES (
+                    :review_id, :app_id, :service_id, :platform_review_id, 'APPSTORE',
+                    :reviewed_at, :reviewed_at, 'ANALYZED',
+                    :reviewed_at, :storage_path, 0, TRUE, FALSE
+                )
+                """
+            ),
+            {
+                "review_id": review_id,
+                "app_id": app_id,
+                "service_id": service_id,
+                "platform_review_id": platform_review_ids[idx],
+                "reviewed_at": reviewed_at[idx],
+                "storage_path": (
+                    "s3://reai-data/bronze/app_reviews/"
+                    f"{TARGET_DATE.isoformat()}/{review_id}.parquet"
+                ),
+            },
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO app_reviews (
+                    review_id, app_id, platform_type, country_code, platform_review_id,
+                    reviewer_name, review_text, rating, app_version, reviewed_at,
+                    is_reply, reply_comment
+                )
+                VALUES (
+                    :review_id, :app_id, 'APPSTORE', 'kr', :platform_review_id,
+                    :reviewer_name, :review_text, :rating, '9.9.9', :reviewed_at,
+                    FALSE, NULL
+                )
+                """
+            ),
+            {
+                "review_id": review_id,
+                "app_id": app_id,
+                "platform_review_id": platform_review_ids[idx],
+                "reviewer_name": f"serving-readiness-{idx}",
+                "review_text": [
+                    "Login fails after update and blocks transfers",
+                    "Transfers are fast and stable",
+                    "Login error appears but the new design is clean",
+                ][idx],
+                "rating": [1, 5, 4][idx],
+                "reviewed_at": reviewed_at[idx],
+            },
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO reviews_preprocessed (review_id, platform_review_id, refined_text)
+                VALUES (:review_id, :platform_review_id, :refined_text)
+                """
+            ),
+            {
+                "review_id": review_id,
+                "platform_review_id": platform_review_ids[idx],
+                "refined_text": [
+                    "login fails after update",
+                    "transfer is fast and stable",
+                    "login error but clean design",
+                ][idx],
+            },
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO review_action_analysis (
+                    review_id, is_action_required, action_confidence_score,
+                    trigger_reason, is_attention_required, is_verified,
+                    analyzed_at, review_summary
+                )
+                VALUES (
+                    :review_id, :is_action_required, :action_confidence_score,
+                    :trigger_reason, :is_attention_required, TRUE,
+                    :reviewed_at, :review_summary
+                )
+                """
+            ),
+            {
+                "review_id": review_id,
+                "is_action_required": [True, False, True][idx],
+                "action_confidence_score": [0.95, 0.1, 0.77][idx],
+                "trigger_reason": ["login failure", "positive speed", "login error"][
+                    idx
+                ],
+                "is_attention_required": [True, False, True][idx],
+                "reviewed_at": reviewed_at[idx],
+                "review_summary": [
+                    "Login failure needs CX follow-up",
+                    "Transfer speed is positive",
+                    "Login error with positive design note",
+                ][idx],
+            },
+        )
+        session.execute(
+            text(
+                """
+                INSERT INTO reviews_assigned (
+                    review_id, assigned_dept, assignment_reason,
+                    confidence, is_failed, try_number
+                )
+                VALUES (
+                    :review_id, :assigned_dept, :assignment_reason,
+                    :confidence, FALSE, 1
+                )
+                """
+            ),
+            {
+                "review_id": review_id,
+                "assigned_dept": [["CX", "APP"], ["APP"], ["CX", "DESIGN"]][idx],
+                "assignment_reason": ["login", "speed", "login-design"][idx],
+                "confidence": [0.93, 0.88, 0.81][idx],
+            },
+        )
+
+    aspect_rows = [
+        (review_ids[0], "login", 0.2, "USABILITY"),
+        (review_ids[1], "transfer", 0.9, "SPEED"),
+        (review_ids[2], "login", 0.6, "USABILITY"),
+        (review_ids[2], "design", 0.8, "OTHER"),
+    ]
+    for review_id, keyword, score, category in aspect_rows:
+        session.execute(
+            text(
+                """
+                INSERT INTO review_aspects (review_id, keyword, sentiment_score, category)
+                VALUES (:review_id, :keyword, :sentiment_score, :category)
+                """
+            ),
+            {
+                "review_id": review_id,
+                "keyword": keyword,
+                "sentiment_score": score,
+                "category": category,
+            },
+        )
+
+
+def _fetch_row_counts(session, service_id) -> dict[str, int]:
+    counts = {}
+    for table_name in EXPECTED_TABLES:
+        counts[table_name] = session.execute(
+            text(
+                f"""
+                SELECT COUNT(*)
+                FROM {table_name}
+                WHERE date = :target_date
+                  AND service_id = :service_id
+                """
+            ),
+            {"target_date": TARGET_DATE, "service_id": service_id},
+        ).scalar_one()
+    return counts
+
+
+def _cleanup_serving_readiness_rows(
+    session,
+    *,
+    service_id,
+    app_id,
+    review_ids,
+    platform_review_ids,
+) -> None:
+    params = {
+        "target_date": TARGET_DATE,
+        "service_id": service_id,
+        "app_id": app_id,
+        "review_ids": tuple(review_ids),
+        "platform_review_ids": tuple(platform_review_ids),
+    }
+    session.execute(
+        text(
+            "DELETE FROM srv_daily_review_list "
+            "WHERE date = :target_date AND service_id = :service_id"
+        ),
+        params,
+    )
+    session.execute(
+        text(
+            "DELETE FROM fact_category_radar_scores "
+            "WHERE date = :target_date AND service_id = :service_id"
+        ),
+        params,
+    )
+    session.execute(
+        text(
+            "DELETE FROM fact_service_aspect_daily "
+            "WHERE date = :target_date AND service_id = :service_id"
+        ),
+        params,
+    )
+    session.execute(
+        text(
+            "DELETE FROM fact_service_review_daily "
+            "WHERE date = :target_date AND service_id = :service_id"
+        ),
+        params,
+    )
+    session.execute(text("DELETE FROM reviews_assigned WHERE review_id IN :review_ids"), params)
+    session.execute(
+        text("DELETE FROM review_action_analysis WHERE review_id IN :review_ids"),
+        params,
+    )
+    session.execute(text("DELETE FROM review_aspects WHERE review_id IN :review_ids"), params)
+    session.execute(
+        text("DELETE FROM reviews_preprocessed WHERE review_id IN :review_ids"),
+        params,
+    )
+    session.execute(
+        text("DELETE FROM app_reviews WHERE platform_review_id IN :platform_review_ids"),
+        params,
+    )
+    session.execute(
+        text("DELETE FROM review_master_index WHERE review_id IN :review_ids"),
+        params,
+    )
+    session.execute(text("DELETE FROM apps WHERE app_id = :app_id"), params)
+    session.execute(text("DELETE FROM app_service WHERE service_id = :service_id"), params)

--- a/tests/test_backend_datamart_serving_readiness.py
+++ b/tests/test_backend_datamart_serving_readiness.py
@@ -11,7 +11,7 @@ from datetime import date, datetime, timezone
 from pathlib import Path
 
 import pytest
-from sqlalchemy import create_engine, text
+from sqlalchemy import bindparam, create_engine, text
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import NullPool
 from uuid6 import uuid7
@@ -33,6 +33,41 @@ EXPECTED_TABLES = (
     "fact_category_radar_scores",
     "srv_daily_review_list",
 )
+ROW_COUNT_STATEMENTS = {
+    "fact_service_review_daily": text(
+        """
+        SELECT COUNT(*)
+        FROM fact_service_review_daily
+        WHERE date = :target_date
+          AND service_id = :service_id
+        """
+    ),
+    "fact_service_aspect_daily": text(
+        """
+        SELECT COUNT(*)
+        FROM fact_service_aspect_daily
+        WHERE date = :target_date
+          AND service_id = :service_id
+        """
+    ),
+    "fact_category_radar_scores": text(
+        """
+        SELECT COUNT(*)
+        FROM fact_category_radar_scores
+        WHERE date = :target_date
+          AND service_id = :service_id
+        """
+    ),
+    "srv_daily_review_list": text(
+        """
+        SELECT COUNT(*)
+        FROM srv_daily_review_list
+        WHERE date = :target_date
+          AND service_id = :service_id
+        """
+    ),
+}
+assert tuple(ROW_COUNT_STATEMENTS) == EXPECTED_TABLES
 
 
 @pytest.mark.requires_db
@@ -79,7 +114,7 @@ def test_backend_datamarts_are_populated_by_real_pipeline_cli_aggregate_step(
             assert row_counts == {
                 "fact_service_review_daily": 1,
                 "fact_service_aspect_daily": 3,
-                "fact_category_radar_scores": 2,
+                "fact_category_radar_scores": 3,
                 "srv_daily_review_list": 3,
             }
 
@@ -144,6 +179,7 @@ def test_backend_datamarts_are_populated_by_real_pipeline_cli_aggregate_step(
                 (row.category_type, float(row.score), row.review_cnt)
                 for row in radar
             ] == [
+                ("DESIGN", 0.8, 1),
                 ("SPEED", 0.9, 1),
                 ("USABILITY", 0.4, 2),
             ]
@@ -381,7 +417,7 @@ def _seed_analyzed_pipeline_rows(
         (review_ids[0], "login", 0.2, "USABILITY"),
         (review_ids[1], "transfer", 0.9, "SPEED"),
         (review_ids[2], "login", 0.6, "USABILITY"),
-        (review_ids[2], "design", 0.8, "OTHER"),
+        (review_ids[2], "design", 0.8, "DESIGN"),
     ]
     for review_id, keyword, score, category in aspect_rows:
         session.execute(
@@ -402,16 +438,9 @@ def _seed_analyzed_pipeline_rows(
 
 def _fetch_row_counts(session, service_id) -> dict[str, int]:
     counts = {}
-    for table_name in EXPECTED_TABLES:
+    for table_name, statement in ROW_COUNT_STATEMENTS.items():
         counts[table_name] = session.execute(
-            text(
-                f"""
-                SELECT COUNT(*)
-                FROM {table_name}
-                WHERE date = :target_date
-                  AND service_id = :service_id
-                """
-            ),
+            statement,
             {"target_date": TARGET_DATE, "service_id": service_id},
         ).scalar_one()
     return counts
@@ -429,8 +458,8 @@ def _cleanup_serving_readiness_rows(
         "target_date": TARGET_DATE,
         "service_id": service_id,
         "app_id": app_id,
-        "review_ids": tuple(review_ids),
-        "platform_review_ids": tuple(platform_review_ids),
+        "review_ids": list(review_ids),
+        "platform_review_ids": list(platform_review_ids),
     }
     session.execute(
         text(
@@ -460,23 +489,51 @@ def _cleanup_serving_readiness_rows(
         ),
         params,
     )
-    session.execute(text("DELETE FROM reviews_assigned WHERE review_id IN :review_ids"), params)
     session.execute(
-        text("DELETE FROM review_action_analysis WHERE review_id IN :review_ids"),
-        params,
-    )
-    session.execute(text("DELETE FROM review_aspects WHERE review_id IN :review_ids"), params)
-    session.execute(
-        text("DELETE FROM reviews_preprocessed WHERE review_id IN :review_ids"),
+        _text_with_expanding_param(
+            "DELETE FROM reviews_assigned WHERE review_id IN :review_ids",
+            "review_ids",
+        ),
         params,
     )
     session.execute(
-        text("DELETE FROM app_reviews WHERE platform_review_id IN :platform_review_ids"),
+        _text_with_expanding_param(
+            "DELETE FROM review_action_analysis WHERE review_id IN :review_ids",
+            "review_ids",
+        ),
         params,
     )
     session.execute(
-        text("DELETE FROM review_master_index WHERE review_id IN :review_ids"),
+        _text_with_expanding_param(
+            "DELETE FROM review_aspects WHERE review_id IN :review_ids",
+            "review_ids",
+        ),
+        params,
+    )
+    session.execute(
+        _text_with_expanding_param(
+            "DELETE FROM reviews_preprocessed WHERE review_id IN :review_ids",
+            "review_ids",
+        ),
+        params,
+    )
+    session.execute(
+        _text_with_expanding_param(
+            "DELETE FROM app_reviews WHERE platform_review_id IN :platform_review_ids",
+            "platform_review_ids",
+        ),
+        params,
+    )
+    session.execute(
+        _text_with_expanding_param(
+            "DELETE FROM review_master_index WHERE review_id IN :review_ids",
+            "review_ids",
+        ),
         params,
     )
     session.execute(text("DELETE FROM apps WHERE app_id = :app_id"), params)
     session.execute(text("DELETE FROM app_service WHERE service_id = :service_id"), params)
+
+
+def _text_with_expanding_param(sql: str, param_name: str):
+    return text(sql).bindparams(bindparam(param_name, expanding=True))

--- a/tests/test_batch_loader.py
+++ b/tests/test_batch_loader.py
@@ -11,10 +11,11 @@ This module tests the load stage of the Batch DLQ architecture:
 """
 
 import pytest
-from pathlib import Path
 from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
 from uuid6 import uuid7
+
+from sqlalchemy import text
 
 from src.loaders.batch_loader import BatchLoader
 from src.models.app_metadata import AppMetadata
@@ -318,6 +319,84 @@ def test_service_id_populated_from_app_metadata(test_db_session):
     ).first()
     assert review is not None
     assert review.service_id == service_id, "service_id should be populated from app_metadata"
+
+
+@pytest.mark.requires_db
+def test_load_bare_minio_object_key_from_daily_crawl_batch(test_db_session):
+    """Daily crawler batches store a bare MinIO key; loader must read it from MinIO."""
+    import pyarrow as pa
+    from datetime import date
+
+    now = datetime.now(timezone.utc)
+    app_id = uuid7()
+    service_id = uuid7()
+
+    service = AppService(service_id=service_id, service_name='Seeded Service')
+    app = App(
+        app_id=app_id,
+        platform_app_id='seeded_appstore_001',
+        platform_type=PlatformType.APPSTORE,
+        name='Seeded App',
+    )
+    metadata = AppMetadata(
+        app_id=app_id,
+        service_id=service_id,
+        is_active=True,
+        valid_from=date.today(),
+    )
+    test_db_session.add_all([service, app, metadata])
+    test_db_session.commit()
+
+    review_schema = AppReviewSchema(
+        review_id=str(uuid7()),
+        app_id=str(app_id),
+        platform_type='APPSTORE',
+        platform_review_id='daily_crawl_review_001',
+        reviewer_name='Seed User',
+        review_text='공식 seed 앱에서 수집한 리뷰',
+        rating=4,
+        reviewed_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+        is_reply=False,
+        reply_comment=None,
+    )
+    batch = IngestionBatch(
+        batch_id=uuid7(),
+        source_type=PlatformType.APPSTORE,
+        platform_app_id='daily_batch',
+        app_name=None,
+        storage_path=(
+            'bronze/app_reviews/year=2026/month=05/day=03/'
+            'appstore_20260503_145830_064432.parquet'
+        ),
+        file_format='parquet',
+        record_count=1,
+        status=IngestionBatchStatusType.PENDING,
+        retry_count=0,
+        max_retries=3,
+        created_at=now,
+        updated_at=now,
+    )
+    test_db_session.add(batch)
+    test_db_session.commit()
+
+    loader = _make_loader(test_db_session)
+    loader._minio = MagicMock()
+    loader._minio.get_parquet.return_value = pa.Table.from_pylist([review_schema.model_dump()])
+
+    loaded = loader.load_pending_batches(limit=100)
+
+    assert loaded == 1
+    loader._minio.get_parquet.assert_called_once_with(batch.storage_path)
+    review = test_db_session.query(ReviewMasterIndex).filter_by(
+        platform_review_id='daily_crawl_review_001'
+    ).one()
+    assert review.service_id == service_id
+    assert batch.status == IngestionBatchStatusType.LOADED
+    assert batch.error_message is None
+    stored_review_count = test_db_session.execute(
+        text("SELECT COUNT(*) FROM app_reviews WHERE platform_review_id = 'daily_crawl_review_001'")
+    ).scalar_one()
+    assert stored_review_count == 1
 
 
 @pytest.mark.requires_db

--- a/tests/test_batch_loader.py
+++ b/tests/test_batch_loader.py
@@ -134,6 +134,19 @@ def test_load_missing_parquet_marks_failed(test_db_session, temp_bronze_dir):
     assert updated_batch.error_message is not None
 
 
+def test_read_missing_absolute_parquet_path_fails_without_minio(tmp_path):
+    """Absolute local paths must fail locally instead of falling through to MinIO."""
+    loader = BatchLoader.__new__(BatchLoader)
+    loader._minio = MagicMock()
+
+    missing_path = tmp_path / "missing.parquet"
+
+    with pytest.raises(FileNotFoundError, match="Parquet file not found"):
+        loader._read_batch_table(str(missing_path))
+
+    loader._minio.get_parquet.assert_not_called()
+
+
 @pytest.mark.requires_db
 def test_load_db_failure_marks_batch_failed(test_db_session, db_with_pending_batches):
     """Test DB failure causes FAILED status + retry_count increment."""

--- a/tests/test_batch_loader.py
+++ b/tests/test_batch_loader.py
@@ -17,7 +17,7 @@ from uuid6 import uuid7
 
 from sqlalchemy import text
 
-from src.loaders.batch_loader import BatchLoader
+from src.loaders.batch_loader import BatchLoader, _object_key_from_storage_path
 from src.models.app_metadata import AppMetadata
 from src.models.app_service import AppService
 from src.models.apps import App
@@ -397,6 +397,75 @@ def test_load_bare_minio_object_key_from_daily_crawl_batch(test_db_session):
         text("SELECT COUNT(*) FROM app_reviews WHERE platform_review_id = 'daily_crawl_review_001'")
     ).scalar_one()
     assert stored_review_count == 1
+
+
+def test_object_key_from_storage_path_preserves_minio_key_prefix():
+    assert (
+        _object_key_from_storage_path(
+            "minio://bronze/app_reviews/year=2026/month=05/file.parquet"
+        )
+        == "bronze/app_reviews/year=2026/month=05/file.parquet"
+    )
+    assert (
+        _object_key_from_storage_path(
+            "s3://reai-data/bronze/app_reviews/year=2026/month=05/file.parquet"
+        )
+        == "bronze/app_reviews/year=2026/month=05/file.parquet"
+    )
+    assert (
+        _object_key_from_storage_path(
+            "bronze/app_reviews/year=2026/month=05/file.parquet"
+        )
+        == "bronze/app_reviews/year=2026/month=05/file.parquet"
+    )
+
+
+@pytest.mark.requires_db
+def test_daily_batch_missing_app_seed_fails_without_synthetic_daily_app(test_db_session):
+    """Daily crawl batches must rely on seeded App rows, not a synthetic daily_batch app."""
+    import pyarrow as pa
+
+    now = datetime.now(timezone.utc)
+    missing_app_id = uuid7()
+    review_schema = AppReviewSchema(
+        review_id=str(uuid7()),
+        app_id=str(missing_app_id),
+        platform_type='APPSTORE',
+        platform_review_id='daily_missing_seed_review_001',
+        reviewer_name='Seed User',
+        review_text='Missing seed app should fail',
+        rating=4,
+        reviewed_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+        is_reply=False,
+        reply_comment=None,
+    )
+    batch = IngestionBatch(
+        batch_id=uuid7(),
+        source_type=PlatformType.APPSTORE,
+        platform_app_id='daily_batch',
+        app_name=None,
+        storage_path='bronze/app_reviews/year=2026/month=05/day=03/missing_seed.parquet',
+        file_format='parquet',
+        record_count=1,
+        status=IngestionBatchStatusType.PENDING,
+        retry_count=0,
+        max_retries=3,
+        created_at=now,
+        updated_at=now,
+    )
+    test_db_session.add(batch)
+    test_db_session.commit()
+
+    loader = _make_loader(test_db_session)
+    loader._minio = MagicMock()
+    loader._minio.get_parquet.return_value = pa.Table.from_pylist([review_schema.model_dump()])
+
+    loaded = loader.load_pending_batches(limit=100)
+
+    assert loaded == 0
+    assert batch.status == IngestionBatchStatusType.FAILED
+    assert "Daily batch requires app seed rows" in batch.error_message
+    assert test_db_session.query(App).filter_by(platform_app_id='daily_batch').count() == 0
 
 
 @pytest.mark.requires_db

--- a/tests/test_bronze_loading.py
+++ b/tests/test_bronze_loading.py
@@ -218,6 +218,66 @@ def test_partial_duplicate_batch(test_db_session, temp_bronze_dir):
 
 
 @pytest.mark.requires_db
+def test_duplicate_platform_review_id_within_batch_keeps_first_occurrence(
+    test_db_session,
+    temp_bronze_dir,
+):
+    """Duplicate platform_review_id values in one crawl batch keep only the first review."""
+    crawler = _make_crawler(test_db_session, temp_bronze_dir)
+    app_id = 'batch_duplicate_app'
+    reviews = [
+        {
+            'id': {'label': 'duplicate_in_batch'},
+            'author': {'name': {'label': 'FirstUser'}},
+            'im:name': {'label': 'Test App'},
+            'content': {'label': 'First duplicate review'},
+            'im:rating': {'label': '5'},
+            'updated': {'label': '2026-02-04T12:00:00Z'},
+        },
+        {
+            'id': {'label': 'duplicate_in_batch'},
+            'author': {'name': {'label': 'SecondUser'}},
+            'im:name': {'label': 'Test App'},
+            'content': {'label': 'Second duplicate review'},
+            'im:rating': {'label': '1'},
+            'updated': {'label': '2026-02-05T12:00:00Z'},
+        },
+        {
+            'id': {'label': 'unique_in_batch'},
+            'author': {'name': {'label': 'UniqueUser'}},
+            'im:name': {'label': 'Test App'},
+            'content': {'label': 'Unique review'},
+            'im:rating': {'label': '4'},
+            'updated': {'label': '2026-02-06T12:00:00Z'},
+        },
+    ]
+
+    batch_id, count, parquet_path = crawler.save_crawl_batch(
+        app_id, 'Test App', reviews, crawler._build_parquet_records
+    )
+
+    assert count == 2
+
+    batch = test_db_session.query(IngestionBatch).filter_by(
+        batch_id=batch_id
+    ).one()
+    assert batch.record_count == 2
+
+    records = read_parquet_to_schemas(parquet_path, AppReviewSchema)
+    assert len(records) == 2
+    assert {record.platform_review_id for record in records} == {
+        'duplicate_in_batch',
+        'unique_in_batch',
+    }
+    duplicate_record = next(
+        record for record in records
+        if record.platform_review_id == 'duplicate_in_batch'
+    )
+    assert duplicate_record.review_text == 'First duplicate review'
+    assert duplicate_record.reviewer_name == 'FirstUser'
+
+
+@pytest.mark.requires_db
 def test_empty_new_reviews_returns_zero(test_db_session, temp_bronze_dir):
     """Test that all-duplicate batch returns 0."""
     crawler = _make_crawler(test_db_session, temp_bronze_dir)

--- a/tests/test_bronze_loading.py
+++ b/tests/test_bronze_loading.py
@@ -8,10 +8,7 @@ This module tests the crawl stage of the Batch DLQ architecture:
 """
 
 import pytest
-from pathlib import Path
-from datetime import datetime, timezone
 from unittest.mock import patch, MagicMock
-from uuid6 import uuid7
 
 from src.crawlers.appstore_crawler import AppStoreCrawler
 from src.crawlers.exceptions import ParquetWriteError
@@ -290,12 +287,10 @@ def test_parquet_write_failure_no_ingestion_batch(
         'write_batch',
         side_effect=Exception("Permission denied")
     ):
-        try:
+        with pytest.raises(ParquetWriteError):
             crawler.save_crawl_batch(
                 '123456789', 'Test App', sample_appstore_reviews, crawler._build_parquet_records
             )
-        except ParquetWriteError:
-            pass
 
     # Verify NO ingestion_batch created
     batch_count = test_db_session.query(IngestionBatch).count()
@@ -304,6 +299,30 @@ def test_parquet_write_failure_no_ingestion_batch(
     # Verify NO Parquet files
     parquet_files = list(temp_bronze_dir.glob('**/*.parquet'))
     assert len(parquet_files) == 0
+
+
+@pytest.mark.requires_db
+def test_batch_registration_failure_removes_written_local_parquet(
+    test_db_session,
+    temp_bronze_dir,
+    sample_appstore_reviews,
+    monkeypatch,
+):
+    """Parquet write succeeds but ingestion_batch commit fails → local artifact is removed."""
+    crawler = _make_crawler(test_db_session, temp_bronze_dir)
+
+    def fail_commit():
+        raise RuntimeError("commit down")
+
+    monkeypatch.setattr(test_db_session, "commit", fail_commit)
+
+    with pytest.raises(RuntimeError, match="commit down"):
+        crawler.save_crawl_batch(
+            '123456789', 'Test App', sample_appstore_reviews, crawler._build_parquet_records
+        )
+
+    parquet_files = list(temp_bronze_dir.glob('**/*.parquet'))
+    assert parquet_files == []
 
 
 # ========================================

--- a/tests/test_cleanse.py
+++ b/tests/test_cleanse.py
@@ -8,6 +8,7 @@ import pytest
 from uuid6 import uuid7
 
 from src.models.enums import ProcessingStatusType
+from src.models.review_preprocessed import ReviewPreprocessed
 from src.processing.cleanse import (
     ReviewCleaner,
     ReviewCleaningPipeline,
@@ -456,6 +457,87 @@ def test_mark_review_failed_updates_master_index(tmp_path):
     assert record.retry_count == 3
     mock_session.commit.assert_called_once()
     mock_session.close.assert_called_once()
+
+
+def _make_pipeline_for_update_db_status(tmp_path, db_session):
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+    mock_db = MagicMock()
+    mock_db.get_session.return_value = db_session
+    return ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+
+@pytest.mark.requires_db
+def test_update_db_status_upserts_preprocessed_text_without_rewriting_review_id(
+    tmp_path,
+    test_db_session,
+):
+    review_id = uuid7()
+    platform_review_id = "cleanse-upsert-stable"
+    test_db_session.add(
+        ReviewPreprocessed(
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+            refined_text="old text",
+        )
+    )
+    test_db_session.commit()
+
+    pipeline = _make_pipeline_for_update_db_status(tmp_path, test_db_session)
+    pipeline._update_db_status(
+        [str(review_id)],
+        [
+            {
+                "review_id": str(review_id),
+                "platform_review_id": platform_review_id,
+                "refined_text": "new text",
+            }
+        ],
+    )
+
+    stored = test_db_session.query(ReviewPreprocessed).filter_by(
+        platform_review_id=platform_review_id
+    ).one()
+    assert stored.review_id == review_id
+    assert stored.refined_text == "new text"
+
+
+@pytest.mark.requires_db
+def test_update_db_status_rejects_platform_review_id_review_id_mismatch(
+    tmp_path,
+    test_db_session,
+):
+    stored_review_id = uuid7()
+    incoming_review_id = uuid7()
+    platform_review_id = "cleanse-upsert-mismatch"
+    test_db_session.add(
+        ReviewPreprocessed(
+            review_id=stored_review_id,
+            platform_review_id=platform_review_id,
+            refined_text="old text",
+        )
+    )
+    test_db_session.commit()
+
+    pipeline = _make_pipeline_for_update_db_status(tmp_path, test_db_session)
+    with pytest.raises(ValueError, match="different review_id"):
+        pipeline._update_db_status(
+            [str(incoming_review_id)],
+            [
+                {
+                    "review_id": str(incoming_review_id),
+                    "platform_review_id": platform_review_id,
+                    "refined_text": "new text",
+                }
+            ],
+        )
 
 
 def test_mark_review_failed_ignores_already_processed_review(tmp_path):

--- a/tests/test_cleanse.py
+++ b/tests/test_cleanse.py
@@ -1,11 +1,24 @@
+from datetime import date
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pyarrow as pa
 import pytest
+from uuid6 import uuid7
+
+from src.models.enums import ProcessingStatusType
 from src.processing.cleanse import (
+    ReviewCleaner,
+    ReviewCleaningPipeline,
+    load_bronze_parquet,
     normalize_unicode,
     normalize_whitespace,
     remove_emojis,
     reduce_repeated_chars,
     remove_special_chars,
     mask_pii,
+    write_silver_parquet,
 )
 
 
@@ -149,11 +162,6 @@ def test_normalize_whitespace_empty():
 # ReviewCleaner
 # ========================================
 
-import json
-import tempfile
-from pathlib import Path
-from src.processing.cleanse import ReviewCleaner
-
 
 @pytest.fixture
 def tmp_synonyms(tmp_path):
@@ -219,18 +227,6 @@ def test_cleaner_profanity_dict_format(tmp_synonyms, tmp_profanity_dict):
 # ========================================
 # Bronze 로더 / Silver 라이터 / Pipeline
 # ========================================
-
-import pyarrow as pa
-from datetime import date
-from types import SimpleNamespace
-from unittest.mock import MagicMock
-from uuid6 import uuid7
-from src.processing.cleanse import (
-    load_bronze_parquet,
-    write_silver_parquet,
-    ReviewCleaningPipeline,
-)
-from src.models.enums import ProcessingStatusType
 
 
 def _make_bronze_minio(table: pa.Table):
@@ -670,3 +666,75 @@ def test_update_db_status_recovers_prior_cleanse_failures(tmp_path):
     assert update_values["processing_status"] == ProcessingStatusType.CLEANED
     assert update_values["error_message"] is None
     mock_session.commit.assert_called_once()
+
+
+@pytest.mark.requires_db
+def test_update_db_status_upserts_reviews_preprocessed_rows(tmp_path, test_db_session):
+    """Bronze→Silver 성공 시 DB Gold 입력 테이블도 같이 적재되어야 한다."""
+    from datetime import datetime, timezone
+
+    from src.models.apps import App
+    from src.models.enums import PlatformType
+    from src.models.review_master_index import ReviewMasterIndex
+    from src.models.review_preprocessed import ReviewPreprocessed
+
+    synonyms = {}
+    profanity = []
+    (tmp_path / "synonyms.json").write_text(json.dumps(synonyms))
+    (tmp_path / "profanity.json").write_text(json.dumps(profanity))
+
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = "seed-review-001"
+    test_db_session.add(
+        App(
+            app_id=app_id,
+            platform_app_id="seeded_appstore_001",
+            platform_type=PlatformType.APPSTORE,
+            name="Seeded App",
+        )
+    )
+    test_db_session.add(
+        ReviewMasterIndex(
+            review_id=review_id,
+            app_id=app_id,
+            platform_review_id=platform_review_id,
+            platform_type=PlatformType.APPSTORE,
+            review_created_at=datetime(2026, 5, 3, 12, 0, tzinfo=timezone.utc),
+            ingested_at=datetime(2026, 5, 3, 12, 1, tzinfo=timezone.utc),
+            processing_status=ProcessingStatusType.RAW,
+            parquet_written_at=datetime(2026, 5, 3, 12, 1, tzinfo=timezone.utc),
+            storage_path="bronze/app_reviews/year=2026/month=05/day=03/data.parquet",
+            retry_count=0,
+            is_active=True,
+            is_reply=False,
+        )
+    )
+    test_db_session.commit()
+
+    mock_db = MagicMock()
+    mock_db.get_session.return_value = test_db_session
+    pipeline = ReviewCleaningPipeline(
+        minio_client=MagicMock(),
+        db_connector=mock_db,
+        synonyms_path=str(tmp_path / "synonyms.json"),
+        profanity_path=str(tmp_path / "profanity.json"),
+    )
+
+    pipeline._update_db_status(
+        [str(review_id)],
+        preprocessed_records=[
+            {
+                "review_id": str(review_id),
+                "platform_review_id": platform_review_id,
+                "refined_text": "공식 seed 앱 리뷰 정제문",
+            }
+        ],
+    )
+
+    preprocessed = test_db_session.get(ReviewPreprocessed, review_id)
+    master = test_db_session.get(ReviewMasterIndex, review_id)
+    assert preprocessed is not None
+    assert preprocessed.platform_review_id == platform_review_id
+    assert preprocessed.refined_text == "공식 seed 앱 리뷰 정제문"
+    assert master.processing_status == ProcessingStatusType.CLEANED

--- a/tests/test_gold_aggregator.py
+++ b/tests/test_gold_aggregator.py
@@ -1,7 +1,7 @@
 """Unit tests for GoldAggregator."""
 
 from datetime import date, timedelta
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -366,6 +366,16 @@ class TestDropOldPartitions:
         dropped = agg._drop_old_partitions(session, retention_days=14)
 
         assert dropped == 0
+
+    def test_catalog_query_uses_postgresql_inhparent_column(self):
+        session = self._make_session_with_partitions([])
+        agg = _make_aggregator(MagicMock())
+
+        agg._drop_old_partitions(session, retention_days=14)
+
+        catalog_sql = str(session.execute.call_args_list[0][0][0])
+        assert "i.inhparent" in catalog_sql
+        assert "i.inhparentid" not in catalog_sql
 
     def test_run_calls_drop_old_partitions(self, mock_session):
         agg = _make_aggregator(mock_session)

--- a/tests/test_gold_embedding_generator.py
+++ b/tests/test_gold_embedding_generator.py
@@ -20,6 +20,7 @@ from src.gold.embedding_generator import GoldEmbeddingGenerator
 from src.models.review_embedding import ReviewEmbedding
 from src.models.review_preprocessed import ReviewPreprocessed
 from src.models.review_master_index import ReviewMasterIndex
+from src.models.apps import App
 from src.models.enums import ProcessingStatusType, PlatformType
 
 
@@ -53,6 +54,14 @@ def _add_preprocessed(session, review_id: UUID, text: str = "테스트 리뷰"):
 
 def _add_master_index(session, review_id: UUID, status: ProcessingStatusType):
     app_id = uuid7()
+    session.add(
+        App(
+            app_id=app_id,
+            platform_app_id=f"app_{app_id}",
+            platform_type=PlatformType.APPSTORE,
+            name="Embedding Test App",
+        )
+    )
     rmi = ReviewMasterIndex(
         review_id=review_id,
         app_id=app_id,

--- a/tests/test_minio_client.py
+++ b/tests/test_minio_client.py
@@ -117,6 +117,20 @@ def test_init_partial_credentials_raises(mock_s3_constructor):
         MinIOClient(endpoint=None, access_key='a', secret_key=None, bucket='test')
 
 
+def test_init_missing_bucket_raises(mock_s3_constructor, monkeypatch):
+    """bucket 파라미터와 MINIO_BUCKET 환경변수가 모두 없으면 즉시 실패한다."""
+    monkeypatch.delenv("MINIO_BUCKET", raising=False)
+
+    with pytest.raises(ValueError, match="MINIO_BUCKET"):
+        MinIOClient(endpoint=None, access_key=None, secret_key=None)
+
+
+def test_init_explicit_none_bucket_raises(mock_s3_constructor):
+    """bucket=None은 지연 실패가 아니라 생성자 실패로 처리한다."""
+    with pytest.raises(ValueError, match="MINIO_BUCKET"):
+        MinIOClient(endpoint=None, access_key=None, secret_key=None, bucket=None)
+
+
 def test_init_no_credentials_allowed(mock_s3_constructor):
     """둘 다 None이면 IAM 모드로 정상 초기화된다."""
     client = MinIOClient(endpoint=None, access_key=None, secret_key=None, bucket='test')


### PR DESCRIPTION
## Summary

This PR is now an independent `main`-based PR for backend datamart serving readiness. It was previously stacked on #80 / `codex/issue-75-alembic-roadmap`; the branch has been rebased onto `main` to remove that review dependency.

Unstack evidence:

- Previous PR #82 head: `8af785ca21b7f75fd04e83acd808531b2393eff0`
- New PR #82 head: `aa37981e8d524106a4044805d8a4a05fccf71729`
- Previous base: `codex/issue-75-alembic-roadmap`
- Current base: `main`
- PR #80 remains an independent Alembic roadmap PR.

Changes:

- Documents the backend-facing physical mart table contract.
- Adds contract regression coverage for mart schema/query expectations.
- Adds a production-like local serving-readiness proof using the real aggregate entrypoint.
- Adds Docker PostgreSQL/MinIO test support and manual live-crawl evidence instructions.
- Stabilizes loader/session/FK fixtures so the full test suite remains green under real constraints.
- Fixes PostgreSQL partition catalog lookup for datamart TTL cleanup (`pg_inherits.inhparent`).
- Fixes the official seed + live crawl path so crawled reviews flow into backend-facing marts.

## Scope

Included:

- `fact_service_review_daily`
- `fact_service_aspect_daily`
- `fact_category_radar_scores`
- `srv_daily_review_list`
- local Docker PostgreSQL + MinIO proof path
- real pipeline/CLI aggregate entrypoint proof
- app metadata -> loader -> `review_master_index.service_id` verification
- full-suite regression cleanup needed for readiness confidence

Excluded by design:

- backend API implementation
- new mart tables or views
- broad schema redesign
- production scheduler rollout
- production credentials
- automated live crawl as a PR gate

## Verification after unstack

| Check | Result |
|---|---|
| Rebase PR #82 unique commits onto `origin/main` | PASS — conflict-free |
| PR #80/#82 diff overlap | PASS — only `docs/local-development.md` |
| PR #80-only Alembic/bootstrap files excluded from #82 diff | PASS |
| `PYTHON_DOTENV_DISABLED=1 TEST_DATABASE_URL=postgresql://testuser:testpass@localhost:5433/testdb PYTHONPATH=. uv run pytest -q` | PASS — `318 passed, 1 skipped, 5 warnings` |
| `PYTHON_DOTENV_DISABLED=1 PYTHONPATH=. uv run python -m compileall -q src tests scripts` | PASS |
| changed Python files `uv run --with ruff ruff check ...` | PASS — `All checks passed!` |

## Local metadata-backed PostgreSQL sample

A local Docker PostgreSQL sample was generated with:

- `app_service`, `apps`, and `app_metadata` seed rows
- real local Parquet batch
- `BatchLoader.load_pending_batches(limit=100)`
- real aggregate CLI: `PYTHONPATH=. uv run python -m src.pipeline.cli --steps aggregate --target-date 2026-05-03`

The sample verified that `review_master_index.service_id` was populated from `app_metadata`, and then the four backend marts were populated:

| table_name | rows |
|---|---:|
| `fact_category_radar_scores` | 2 |
| `fact_service_aspect_daily` | 3 |
| `fact_service_review_daily` | 1 |
| `srv_daily_review_list` | 3 |

## Official seed + live crawl proof

The proof was also re-run with the project’s prepared seed SQL instead of temporary metadata fixtures:

- official seed SQL loaded: `app_service=39`, `apps=63`, `app_metadata_active=63`
- official seed app: `우리WON뱅킹` App Store `1470181651`
- live App Store crawl: `50` reviews
- pipeline persistence: `review_master_index=50`, `app_reviews=50`, `reviews_preprocessed=50`, `review_aspects=372`, `review_action_analysis=50`
- datamarts produced: `fact_service_review_daily=28`, `fact_service_aspect_daily=364`, `fact_category_radar_scores=22`, `srv_daily_review_list=11`

Fixes added from this proof:

- `BatchLoader` now reads bare MinIO object keys emitted by daily crawler batches.
- `BatchLoader` persists `app_reviews`, not only `review_master_index`.
- Cleanse persists `reviews_preprocessed` rows for Gold inputs, not only Silver Parquet.
- `Review` ORM model now matches `schema_v4.sql` column `platform_type`.

## Notes

- Manual live crawl smoke evidence path is documented under `docs/evidence/backend-datamart-serving-readiness/README.md`.
- Local-only ERD files remain deliberately excluded from this PR: `reai.vuerd.json`, `docs/current_service_erd.puml`.
- PR #80 is no longer a base dependency for this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved crawl batch handling with deduplication, idempotent batch registration, local Parquet support, and loader support for local/object-storage paths
  * Review model now uses an enum-based platform_type

* **Documentation**
  * Added backend datamart contract, readiness runbook, evidence README, and local development readiness instructions

* **Tests**
  * Extensive integration and contract tests for datamarts, loaders, cleanse, batch handling, and MinIO scenarios

* **Chores**
  * Test stack adds MinIO-backed object storage and persistent test volumes; configurable test DB port and session ownership improvements
<!-- end of auto-generated comment: release notes by coderabbit.ai -->