### PR TITLE
[codex] Gate Airflow daily load readiness with DB validation

### DIFF
--- a/dags/financial_review_pipeline.py
+++ b/dags/financial_review_pipeline.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+# pyright: reportMissingImports=false
 """
 Financial Review ETL Pipeline DAG
 
@@ -11,6 +12,7 @@ Financial Review ETL Pipeline DAG
   3. cleanse_reviews — Bronze Parquet → Silver(reviews_preprocessed), ReviewMasterIndex(CLEANED)
   4. gold_analyze    — GoldOrchestrator: embedding → ABSA → action, ReviewMasterIndex(ANALYZED)
   5. gold_aggregate  — 팩트 테이블 UPSERT (fact_service_review_daily 등 4개)
+  6. post_aggregate_validate — target date DB 검증 및 DAG 성공/실패 판정
 """
 import os
 from datetime import datetime, timedelta
@@ -99,4 +101,23 @@ gold_aggregate = BashOperator(
     execution_timeout=timedelta(hours=1),
 )
 
-crawl_reviews >> load_reviews >> cleanse_reviews >> gold_analyze >> gold_aggregate
+# Step 6: 집계 후 DB 검증
+# 신규 유입 0건은 warning/report로 남기되, 상태 전이·서빙 mart·무결성 실패는 DAG 실패로 전파한다.
+post_aggregate_validate = BashOperator(
+    task_id="post_aggregate_validate",
+    bash_command=(
+        f"cd {PROJECT_ROOT} && PYTHONPATH=. {PYTHON_BIN} -m src.pipeline.cli "
+        "--steps post_aggregate_validate --target-date {{ ds }}"
+    ),
+    dag=dag,
+    execution_timeout=timedelta(minutes=15),
+)
+
+(
+    crawl_reviews
+    >> load_reviews
+    >> cleanse_reviews
+    >> gold_analyze
+    >> gold_aggregate
+    >> post_aggregate_validate
+)

--- a/docs/airflow-continuous-load-readiness.md
+++ b/docs/airflow-continuous-load-readiness.md
@@ -1,0 +1,80 @@
+# Airflow Continuous Load Readiness
+
+## Contract boundary
+
+`financial_review_etl_pipeline`의 운영 성공 기준은 Airflow task 실행 성공에 더해
+`gold_aggregate` 이후 `post_aggregate_validate` DB 검증 task 성공까지 포함한다.
+
+검증 task는 target date(`{{ ds }}`) 기준으로 기존 DB 테이블을 조회한다. 1차 범위에서는
+신규 모니터링 테이블, Slack/Email/PagerDuty, live App Store/Play Store API gate,
+Metabase/Grafana dashboard 구현을 추가하지 않는다.
+
+## Warning vs failure policy
+
+| 판정 | 의미 | Airflow 결과 |
+|---|---|---|
+| `fresh_ingestion` warning | target date 신규 batch/review count가 0건 | 성공 가능, report 확인 |
+| `batch_state` failure | `PENDING`, `FAILED`, `RETRYING`, `DEAD_LETTER` batch가 남음 | task 실패 |
+| `review_state` failure | `RAW`, `CLEANED`, retry-exhausted `FAILED` review가 남음 | task 실패 |
+| `metadata_mapping` failure | `service_id` 또는 active `app_metadata` mapping 누락 | task 실패 |
+| `orphan_integrity` failure | analyzed row의 action/app review/preprocessed/aspect 연결 누락 | task 실패 |
+| `mart_freshness` failure | analyzed upstream이 있는데 target-date mart row가 없음 | task 실패 |
+| `mart_count_consistency` failure | `fact_service_review_daily.total_review_cnt`와 upstream count 불일치 | task 실패 |
+| `mart_quality` failure | mart count/rating/ratio/sentiment/confidence 범위 위반 | task 실패 |
+
+## Operator commands
+
+Airflow task와 동일한 검증은 아래 명령으로 재현한다.
+
+```bash
+PYTHONPATH=. uv run python -m src.pipeline.cli \
+  --steps post_aggregate_validate \
+  --target-date YYYY-MM-DD
+```
+
+집계까지 포함한 로컬 검증은 아래 순서로 실행한다.
+
+```bash
+PYTHONPATH=. uv run python -m src.pipeline.cli \
+  --steps aggregate,post_aggregate_validate \
+  --target-date YYYY-MM-DD
+```
+
+## Interpreting validation output
+
+CLI 로그의 `Result` JSON에서 다음 필드를 확인한다.
+
+| 필드 | 해석 |
+|---|---|
+| `status` | `success`면 필수 DB 검증 통과, `failed`면 Airflow task non-zero 대상 |
+| `warnings` | 실패는 아니지만 운영자가 확인해야 할 report성 신호 |
+| `checks[].severity` | `failure`는 task 실패 기준, `warning`은 report 기준 |
+| `checks[].metrics` | SQL count 기반 원인 파악용 수치 |
+
+## Verification commands
+
+```bash
+PYTHONPATH=. uv run pytest \
+  tests/test_post_aggregate_validation.py \
+  tests/test_pipeline_cli_validation.py \
+  tests/test_airflow_dag_validation_wiring.py \
+  tests/test_airflow_readiness_docs.py
+
+PYTHONPATH=. uv run pytest \
+  tests/test_backend_datamart_contract.py \
+  tests/test_backend_datamart_serving_readiness.py \
+  tests/test_pipeline_steps.py
+```
+
+DB 테스트는 실제 PostgreSQL test DB가 필요하다. 기본 연결은 `TEST_DATABASE_URL` 또는
+`TEST_POSTGRES_PORT`/`docker-compose.test.yml` 정책을 따른다.
+
+## Follow-up: Metabase/Grafana
+
+Metabase/Grafana readiness metrics dashboard는 1차 구현 범위가 아니다. 별도 이슈로
+다음 항목을 등록한다.
+
+- daily ingestion count trend
+- warning/failure check trend
+- mart freshness and row-count trend
+- service/platform breakdown for failed checks

--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -3,31 +3,28 @@ import argparse
 from datetime import date
 import json
 from pathlib import Path
-from typing import List, Optional
 
 try:
-    from dotenv import load_dotenv
-
-    DOTENV_AVAILABLE = True
+    from dotenv import load_dotenv as _load_dotenv
 except ImportError:
-    DOTENV_AVAILABLE = False
+    _load_dotenv = None
 
-from src.pipeline.steps import run_steps
 from src.pipeline.steps import run_crawl, run_extract_features, run_generate_embeddings, run_preprocess, run_action_analysis  # noqa: F401
+from src.pipeline.steps import run_steps
 from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
 
 def _load_dotenv_if_present() -> None:
-    if not DOTENV_AVAILABLE:
+    if _load_dotenv is None:
         return
     env_path = Path(__file__).parent.parent.parent / ".env"
     if env_path.exists():
-        load_dotenv(env_path)
+        _ = _load_dotenv(env_path)
 
 
-def _parse_steps(steps_str: str) -> List[str]:
+def _parse_steps(steps_str: str) -> list[str]:
     steps = [step.strip().lower() for step in steps_str.split(",") if step.strip()]
     return steps
 
@@ -49,7 +46,8 @@ def build_arg_parser() -> argparse.ArgumentParser:
         default="crawl,preprocess,features,action,embed",
         help=(
             "Comma-separated steps to run "
-            "(options: crawl, load, preprocess, features, action, embed, gold, aggregate)"
+            "(options: crawl, load, preprocess, features, action, embed, gold, "
+            "aggregate, post_aggregate_validate, validate)"
         ),
     )
     parser.add_argument("--batch-size", type=int, default=100, help="Batch size for processing steps.")
@@ -65,7 +63,7 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     _load_dotenv_if_present()
     parser = build_arg_parser()
     args = parser.parse_args(argv)

--- a/src/pipeline/post_aggregate_validation.py
+++ b/src/pipeline/post_aggregate_validation.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
-from datetime import date
+from datetime import date, timedelta
 from typing import Any, Literal
 
-from sqlalchemy import bindparam, text
+from sqlalchemy import text
 
 from src.utils.db_connector import DatabaseConnector
 
@@ -20,8 +20,6 @@ MART_TABLES = (
     "fact_category_radar_scores",
     "srv_daily_review_list",
 )
-STUCK_BATCH_STATUSES = ("PENDING", "FAILED", "RETRYING", "DEAD_LETTER")
-STUCK_REVIEW_STATUSES = ("RAW", "CLEANED")
 
 
 @dataclass(frozen=True)
@@ -87,6 +85,13 @@ class PostAggregateValidator:
             checks=checks,
         )
 
+    @staticmethod
+    def _date_window_params(target_date: date) -> dict[str, date]:
+        return {
+            "target_date": target_date,
+            "target_date_end": target_date + timedelta(days=1),
+        }
+
     def _check_fresh_ingestion(self, session, target_date: date) -> ValidationCheck:
         row = session.execute(
             text(
@@ -94,10 +99,11 @@ class PostAggregateValidator:
                 SELECT COUNT(*) AS batch_count,
                        COALESCE(SUM(record_count), 0) AS record_count
                 FROM ingestion_batch
-                WHERE DATE_TRUNC('day', created_at)::date = :target_date
+                WHERE created_at >= :target_date
+                  AND created_at < :target_date_end
                 """
             ),
-            {"target_date": target_date},
+            self._date_window_params(target_date),
         ).one()
         metrics = {
             "batch_count": int(row.batch_count or 0),
@@ -115,15 +121,16 @@ class PostAggregateValidator:
         rows = session.execute(
             text(
                 """
-                SELECT status::text AS status, COUNT(*) AS count
+                SELECT status AS status, COUNT(*) AS count
                 FROM ingestion_batch
-                WHERE DATE_TRUNC('day', created_at)::date = :target_date
-                  AND status::text IN :stuck_statuses
+                WHERE created_at >= :target_date
+                  AND created_at < :target_date_end
+                  AND status IN ('PENDING', 'FAILED', 'RETRYING', 'DEAD_LETTER')
                 GROUP BY status
                 ORDER BY status
                 """
-            ).bindparams(bindparam("stuck_statuses", expanding=True)),
-            {"target_date": target_date, "stuck_statuses": STUCK_BATCH_STATUSES},
+            ),
+            self._date_window_params(target_date),
         ).all()
         by_status = {row.status: int(row.count) for row in rows}
         stuck_count = sum(by_status.values())
@@ -139,28 +146,30 @@ class PostAggregateValidator:
         stuck_rows = session.execute(
             text(
                 """
-                SELECT processing_status::text AS status, COUNT(*) AS count
+                SELECT processing_status AS status, COUNT(*) AS count
                 FROM review_master_index
-                WHERE DATE_TRUNC('day', review_created_at)::date = :target_date
-                  AND processing_status::text IN :stuck_statuses
+                WHERE review_created_at >= :target_date
+                  AND review_created_at < :target_date_end
+                  AND processing_status IN ('RAW', 'CLEANED')
                 GROUP BY processing_status
                 ORDER BY processing_status
                 """
-            ).bindparams(bindparam("stuck_statuses", expanding=True)),
-            {"target_date": target_date, "stuck_statuses": STUCK_REVIEW_STATUSES},
+            ),
+            self._date_window_params(target_date),
         ).all()
         failed_exhausted = session.execute(
             text(
                 """
                 SELECT COUNT(*) AS count
                 FROM review_master_index
-                WHERE DATE_TRUNC('day', review_created_at)::date = :target_date
-                  AND processing_status::text = 'FAILED'
+                WHERE review_created_at >= :target_date
+                  AND review_created_at < :target_date_end
+                  AND processing_status = 'FAILED'
                   AND COALESCE(retry_count, 0) >= :retry_exhausted_threshold
                 """
             ),
             {
-                "target_date": target_date,
+                **self._date_window_params(target_date),
                 "retry_exhausted_threshold": RETRY_EXHAUSTED_THRESHOLD,
             },
         ).scalar_one()
@@ -194,11 +203,12 @@ class PostAggregateValidator:
                  AND am.is_active IS TRUE
                  AND (am.valid_from IS NULL OR am.valid_from <= :target_date)
                  AND (am.valid_to IS NULL OR am.valid_to >= :target_date)
-                WHERE DATE_TRUNC('day', rmi.review_created_at)::date = :target_date
-                  AND rmi.processing_status::text = 'ANALYZED'
+                WHERE rmi.review_created_at >= :target_date
+                  AND rmi.review_created_at < :target_date_end
+                  AND rmi.processing_status = 'ANALYZED'
                 """
             ),
-            {"target_date": target_date},
+            self._date_window_params(target_date),
         ).one()
         missing_service_id = int(row.missing_service_id or 0)
         missing_active_mapping = int(row.missing_active_mapping or 0)
@@ -221,8 +231,9 @@ class PostAggregateValidator:
                 WITH target AS (
                     SELECT rmi.review_id, rmi.platform_review_id
                     FROM review_master_index rmi
-                    WHERE DATE_TRUNC('day', rmi.review_created_at)::date = :target_date
-                      AND rmi.processing_status::text = 'ANALYZED'
+                    WHERE rmi.review_created_at >= :target_date
+                      AND rmi.review_created_at < :target_date_end
+                      AND rmi.processing_status = 'ANALYZED'
                 )
                 SELECT
                     COUNT(*) FILTER (WHERE raa.review_id IS NULL) AS missing_action_analysis,
@@ -237,14 +248,16 @@ class PostAggregateValidator:
                 LEFT JOIN reviews_preprocessed rp
                   ON rp.review_id = t.review_id
                 LEFT JOIN (
-                    SELECT review_id, COUNT(*) AS aspect_count
-                    FROM review_aspects
-                    GROUP BY review_id
+                    SELECT ra.review_id, COUNT(*) AS aspect_count
+                    FROM review_aspects ra
+                    JOIN target t_aspect
+                      ON t_aspect.review_id = ra.review_id
+                    GROUP BY ra.review_id
                 ) aspect_counts
                   ON aspect_counts.review_id = t.review_id
                 """
             ),
-            {"target_date": target_date},
+            self._date_window_params(target_date),
         ).one()
         metrics = {
             "missing_action_analysis": int(row.missing_action_analysis or 0),
@@ -289,13 +302,14 @@ class PostAggregateValidator:
                 FROM review_master_index rmi
                 JOIN app_reviews ar
                   ON ar.platform_review_id = rmi.platform_review_id
-                WHERE DATE_TRUNC('day', rmi.review_created_at)::date = :target_date
-                  AND rmi.processing_status::text = 'ANALYZED'
+                WHERE rmi.review_created_at >= :target_date
+                  AND rmi.review_created_at < :target_date_end
+                  AND rmi.processing_status = 'ANALYZED'
                   AND rmi.service_id IS NOT NULL
                   AND ar.platform_type IS NOT NULL
                 """
             ),
-            {"target_date": target_date},
+            self._date_window_params(target_date),
         ).scalar_one()
         fact_total = session.execute(
             text(
@@ -413,11 +427,12 @@ class PostAggregateValidator:
                     """
                     SELECT COUNT(*) AS count
                     FROM review_master_index
-                    WHERE DATE_TRUNC('day', review_created_at)::date = :target_date
-                      AND processing_status::text = 'ANALYZED'
+                    WHERE review_created_at >= :target_date
+                      AND review_created_at < :target_date_end
+                      AND processing_status = 'ANALYZED'
                     """
                 ),
-                {"target_date": target_date},
+                self._date_window_params(target_date),
             ).scalar_one()
             or 0
         )

--- a/src/pipeline/post_aggregate_validation.py
+++ b/src/pipeline/post_aggregate_validation.py
@@ -1,0 +1,435 @@
+"""Post-aggregate database readiness validation for Airflow DAGs."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from datetime import date
+from typing import Any, Literal
+
+from sqlalchemy import bindparam, text
+
+from src.utils.db_connector import DatabaseConnector
+
+
+Severity = Literal["failure", "warning", "report"]
+
+RETRY_EXHAUSTED_THRESHOLD = 3
+MART_TABLES = (
+    "fact_service_review_daily",
+    "fact_service_aspect_daily",
+    "fact_category_radar_scores",
+    "srv_daily_review_list",
+)
+STUCK_BATCH_STATUSES = ("PENDING", "FAILED", "RETRYING", "DEAD_LETTER")
+STUCK_REVIEW_STATUSES = ("RAW", "CLEANED")
+
+
+@dataclass(frozen=True)
+class ValidationCheck:
+    """Single post-aggregate validation check result."""
+
+    name: str
+    severity: Severity
+    passed: bool
+    metrics: dict[str, Any] = field(default_factory=dict)
+    message: str | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ValidationReport:
+    """Serializable validation report consumed by CLI and Airflow tasks."""
+
+    target_date: str
+    status: Literal["success", "failed"]
+    warnings: list[str]
+    checks: list[ValidationCheck]
+
+    def as_dict(self) -> dict[str, Any]:
+        return {
+            "target_date": self.target_date,
+            "status": self.status,
+            "warnings": self.warnings,
+            "checks": [check.as_dict() for check in self.checks],
+        }
+
+
+class PostAggregateValidator:
+    """Validate target-date DB state after Gold aggregation."""
+
+    def __init__(self, config_path: str | None = None):
+        self.db_connector = DatabaseConnector(config_path) if config_path is not None else DatabaseConnector()
+
+    def validate(self, target_date: date) -> ValidationReport:
+        session = self.db_connector.get_session()
+        try:
+            checks = [
+                self._check_fresh_ingestion(session, target_date),
+                self._check_batch_state(session, target_date),
+                self._check_review_state(session, target_date),
+                self._check_metadata_mapping(session, target_date),
+                self._check_orphan_integrity(session, target_date),
+                self._check_mart_freshness(session, target_date),
+                self._check_mart_count_consistency(session, target_date),
+                self._check_mart_quality(session, target_date),
+            ]
+        finally:
+            session.close()
+
+        failed = [check for check in checks if check.severity == "failure" and not check.passed]
+        warnings = [check.name for check in checks if check.severity == "warning" and not check.passed]
+        return ValidationReport(
+            target_date=target_date.isoformat(),
+            status="failed" if failed else "success",
+            warnings=warnings,
+            checks=checks,
+        )
+
+    def _check_fresh_ingestion(self, session, target_date: date) -> ValidationCheck:
+        row = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS batch_count,
+                       COALESCE(SUM(record_count), 0) AS record_count
+                FROM ingestion_batch
+                WHERE DATE_TRUNC('day', created_at)::date = :target_date
+                """
+            ),
+            {"target_date": target_date},
+        ).one()
+        metrics = {
+            "batch_count": int(row.batch_count or 0),
+            "record_count": int(row.record_count or 0),
+        }
+        return ValidationCheck(
+            name="fresh_ingestion",
+            severity="warning",
+            passed=metrics["record_count"] > 0,
+            metrics=metrics,
+            message="No fresh ingestion rows for target date." if metrics["record_count"] == 0 else None,
+        )
+
+    def _check_batch_state(self, session, target_date: date) -> ValidationCheck:
+        rows = session.execute(
+            text(
+                """
+                SELECT status::text AS status, COUNT(*) AS count
+                FROM ingestion_batch
+                WHERE DATE_TRUNC('day', created_at)::date = :target_date
+                  AND status::text IN :stuck_statuses
+                GROUP BY status
+                ORDER BY status
+                """
+            ).bindparams(bindparam("stuck_statuses", expanding=True)),
+            {"target_date": target_date, "stuck_statuses": STUCK_BATCH_STATUSES},
+        ).all()
+        by_status = {row.status: int(row.count) for row in rows}
+        stuck_count = sum(by_status.values())
+        return ValidationCheck(
+            name="batch_state",
+            severity="failure",
+            passed=stuck_count == 0,
+            metrics={"stuck_count": stuck_count, "by_status": by_status},
+            message="Unresolved ingestion batches remain." if stuck_count else None,
+        )
+
+    def _check_review_state(self, session, target_date: date) -> ValidationCheck:
+        stuck_rows = session.execute(
+            text(
+                """
+                SELECT processing_status::text AS status, COUNT(*) AS count
+                FROM review_master_index
+                WHERE DATE_TRUNC('day', review_created_at)::date = :target_date
+                  AND processing_status::text IN :stuck_statuses
+                GROUP BY processing_status
+                ORDER BY processing_status
+                """
+            ).bindparams(bindparam("stuck_statuses", expanding=True)),
+            {"target_date": target_date, "stuck_statuses": STUCK_REVIEW_STATUSES},
+        ).all()
+        failed_exhausted = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS count
+                FROM review_master_index
+                WHERE DATE_TRUNC('day', review_created_at)::date = :target_date
+                  AND processing_status::text = 'FAILED'
+                  AND COALESCE(retry_count, 0) >= :retry_exhausted_threshold
+                """
+            ),
+            {
+                "target_date": target_date,
+                "retry_exhausted_threshold": RETRY_EXHAUSTED_THRESHOLD,
+            },
+        ).scalar_one()
+        analyzed_count = self._analyzed_count(session, target_date)
+        by_status = {row.status: int(row.count) for row in stuck_rows}
+        stuck_count = sum(by_status.values()) + int(failed_exhausted or 0)
+        return ValidationCheck(
+            name="review_state",
+            severity="failure",
+            passed=stuck_count == 0,
+            metrics={
+                "analyzed_count": analyzed_count,
+                "stuck_count": stuck_count,
+                "by_status": by_status,
+                "retry_exhausted_failed_count": int(failed_exhausted or 0),
+            },
+            message="Review state flow has unresolved or retry-exhausted rows." if stuck_count else None,
+        )
+
+    def _check_metadata_mapping(self, session, target_date: date) -> ValidationCheck:
+        row = session.execute(
+            text(
+                """
+                SELECT
+                    COUNT(*) FILTER (WHERE rmi.service_id IS NULL) AS missing_service_id,
+                    COUNT(*) FILTER (WHERE rmi.service_id IS NOT NULL AND am.id IS NULL) AS missing_active_mapping
+                FROM review_master_index rmi
+                LEFT JOIN app_metadata am
+                  ON am.app_id = rmi.app_id
+                 AND am.service_id = rmi.service_id
+                 AND am.is_active IS TRUE
+                 AND (am.valid_from IS NULL OR am.valid_from <= :target_date)
+                 AND (am.valid_to IS NULL OR am.valid_to >= :target_date)
+                WHERE DATE_TRUNC('day', rmi.review_created_at)::date = :target_date
+                  AND rmi.processing_status::text = 'ANALYZED'
+                """
+            ),
+            {"target_date": target_date},
+        ).one()
+        missing_service_id = int(row.missing_service_id or 0)
+        missing_active_mapping = int(row.missing_active_mapping or 0)
+        missing_count = missing_service_id + missing_active_mapping
+        return ValidationCheck(
+            name="metadata_mapping",
+            severity="failure",
+            passed=missing_count == 0,
+            metrics={
+                "missing_service_id": missing_service_id,
+                "missing_active_mapping": missing_active_mapping,
+            },
+            message="Analyzed reviews have missing service metadata mapping." if missing_count else None,
+        )
+
+    def _check_orphan_integrity(self, session, target_date: date) -> ValidationCheck:
+        row = session.execute(
+            text(
+                """
+                WITH target AS (
+                    SELECT rmi.review_id, rmi.platform_review_id
+                    FROM review_master_index rmi
+                    WHERE DATE_TRUNC('day', rmi.review_created_at)::date = :target_date
+                      AND rmi.processing_status::text = 'ANALYZED'
+                )
+                SELECT
+                    COUNT(*) FILTER (WHERE raa.review_id IS NULL) AS missing_action_analysis,
+                    COUNT(*) FILTER (WHERE ar.platform_review_id IS NULL) AS missing_app_review,
+                    COUNT(*) FILTER (WHERE rp.review_id IS NULL) AS missing_preprocessed,
+                    COUNT(*) FILTER (WHERE aspect_counts.aspect_count IS NULL) AS missing_aspects
+                FROM target t
+                LEFT JOIN review_action_analysis raa
+                  ON raa.review_id = t.review_id
+                LEFT JOIN app_reviews ar
+                  ON ar.platform_review_id = t.platform_review_id
+                LEFT JOIN reviews_preprocessed rp
+                  ON rp.review_id = t.review_id
+                LEFT JOIN (
+                    SELECT review_id, COUNT(*) AS aspect_count
+                    FROM review_aspects
+                    GROUP BY review_id
+                ) aspect_counts
+                  ON aspect_counts.review_id = t.review_id
+                """
+            ),
+            {"target_date": target_date},
+        ).one()
+        metrics = {
+            "missing_action_analysis": int(row.missing_action_analysis or 0),
+            "missing_app_review": int(row.missing_app_review or 0),
+            "missing_preprocessed": int(row.missing_preprocessed or 0),
+            "missing_aspects": int(row.missing_aspects or 0),
+        }
+        missing_count = sum(metrics.values())
+        return ValidationCheck(
+            name="orphan_integrity",
+            severity="failure",
+            passed=missing_count == 0,
+            metrics=metrics,
+            message="Analyzed reviews have missing upstream analysis rows." if missing_count else None,
+        )
+
+    def _check_mart_freshness(self, session, target_date: date) -> ValidationCheck:
+        analyzed_count = self._analyzed_count(session, target_date)
+        row_counts = self._mart_row_counts(session, target_date)
+        missing_tables = [
+            table_name
+            for table_name, row_count in row_counts.items()
+            if analyzed_count > 0 and row_count == 0
+        ]
+        return ValidationCheck(
+            name="mart_freshness",
+            severity="failure",
+            passed=not missing_tables,
+            metrics={"analyzed_count": analyzed_count, "row_counts": row_counts},
+            message=(
+                f"Target-date mart rows are missing: {', '.join(missing_tables)}"
+                if missing_tables
+                else None
+            ),
+        )
+
+    def _check_mart_count_consistency(self, session, target_date: date) -> ValidationCheck:
+        expected_count = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS count
+                FROM review_master_index rmi
+                JOIN app_reviews ar
+                  ON ar.platform_review_id = rmi.platform_review_id
+                WHERE DATE_TRUNC('day', rmi.review_created_at)::date = :target_date
+                  AND rmi.processing_status::text = 'ANALYZED'
+                  AND rmi.service_id IS NOT NULL
+                  AND ar.platform_type IS NOT NULL
+                """
+            ),
+            {"target_date": target_date},
+        ).scalar_one()
+        fact_total = session.execute(
+            text(
+                """
+                SELECT COALESCE(SUM(total_review_cnt), 0) AS count
+                FROM fact_service_review_daily
+                WHERE date = :target_date
+                """
+            ),
+            {"target_date": target_date},
+        ).scalar_one()
+        expected_count = int(expected_count or 0)
+        fact_total = int(fact_total or 0)
+        return ValidationCheck(
+            name="mart_count_consistency",
+            severity="failure",
+            passed=expected_count == fact_total,
+            metrics={
+                "expected_analyzed_review_count": expected_count,
+                "fact_service_review_daily_total": fact_total,
+            },
+            message="Mart summary count does not match analyzed upstream reviews."
+            if expected_count != fact_total
+            else None,
+        )
+
+    def _check_mart_quality(self, session, target_date: date) -> ValidationCheck:
+        summary_violations = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS count
+                FROM fact_service_review_daily
+                WHERE date = :target_date
+                  AND (
+                    COALESCE(total_review_cnt, 0) < 0
+                    OR COALESCE(action_required_cnt, 0) < 0
+                    OR COALESCE(attention_required_cnt, 0) < 0
+                    OR COALESCE(pos_count, 0) < 0
+                    OR COALESCE(neg_count, 0) < 0
+                    OR (avg_rating IS NOT NULL AND (avg_rating < 1 OR avg_rating > 5))
+                    OR (action_ratio IS NOT NULL AND (action_ratio < 0 OR action_ratio > 1))
+                  )
+                """
+            ),
+            {"target_date": target_date},
+        ).scalar_one()
+        aspect_violations = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS count
+                FROM fact_service_aspect_daily
+                WHERE date = :target_date
+                  AND (
+                    COALESCE(mention_cnt, 0) < 0
+                    OR (
+                        avg_sentiment_score IS NOT NULL
+                        AND (avg_sentiment_score < 0 OR avg_sentiment_score > 1)
+                    )
+                  )
+                """
+            ),
+            {"target_date": target_date},
+        ).scalar_one()
+        radar_violations = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS count
+                FROM fact_category_radar_scores
+                WHERE date = :target_date
+                  AND (
+                    COALESCE(review_cnt, 0) < 0
+                    OR (
+                        avg_sentiment_score IS NOT NULL
+                        AND (avg_sentiment_score < 0 OR avg_sentiment_score > 1)
+                    )
+                  )
+                """
+            ),
+            {"target_date": target_date},
+        ).scalar_one()
+        review_list_violations = session.execute(
+            text(
+                """
+                SELECT COUNT(*) AS count
+                FROM srv_daily_review_list
+                WHERE date = :target_date
+                  AND (
+                    (rating IS NOT NULL AND (rating < 1 OR rating > 5))
+                    OR (sentiment_score IS NOT NULL AND (sentiment_score < 0 OR sentiment_score > 1))
+                    OR (confidence IS NOT NULL AND (confidence < 0 OR confidence > 1))
+                  )
+                """
+            ),
+            {"target_date": target_date},
+        ).scalar_one()
+        metrics = {
+            "fact_service_review_daily": int(summary_violations or 0),
+            "fact_service_aspect_daily": int(aspect_violations or 0),
+            "fact_category_radar_scores": int(radar_violations or 0),
+            "srv_daily_review_list": int(review_list_violations or 0),
+        }
+        violation_count = sum(metrics.values())
+        return ValidationCheck(
+            name="mart_quality",
+            severity="failure",
+            passed=violation_count == 0,
+            metrics=metrics,
+            message="Mart rows contain out-of-range quality metrics." if violation_count else None,
+        )
+
+    def _analyzed_count(self, session, target_date: date) -> int:
+        return int(
+            session.execute(
+                text(
+                    """
+                    SELECT COUNT(*) AS count
+                    FROM review_master_index
+                    WHERE DATE_TRUNC('day', review_created_at)::date = :target_date
+                      AND processing_status::text = 'ANALYZED'
+                    """
+                ),
+                {"target_date": target_date},
+            ).scalar_one()
+            or 0
+        )
+
+    def _mart_row_counts(self, session, target_date: date) -> dict[str, int]:
+        counts = {}
+        for table_name in MART_TABLES:
+            counts[table_name] = int(
+                session.execute(
+                    text(f"SELECT COUNT(*) AS count FROM {table_name} WHERE date = :target_date"),
+                    {"target_date": target_date},
+                ).scalar_one()
+                or 0
+            )
+        return counts

--- a/src/pipeline/steps.py
+++ b/src/pipeline/steps.py
@@ -2,7 +2,7 @@
 import warnings
 from dataclasses import asdict, dataclass
 from datetime import datetime
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable
 
 from src.utils.logger import get_logger
 
@@ -20,17 +20,17 @@ def _parse_date_arg(arg_name: str, value: str):
 class RunResult:
     step: str
     status: str
-    input_count: Optional[int] = None
-    output_count: Optional[int] = None
-    output_path: Optional[str] = None
-    validations: Optional[Dict] = None
-    message: Optional[str] = None
+    input_count: int | None = None
+    output_count: int | None = None
+    output_path: str | None = None
+    validations: dict[str, Any] | None = None
+    message: str | None = None
 
-    def as_dict(self) -> Dict:
+    def as_dict(self) -> dict[str, Any]:
         return asdict(self)
 
 
-def _handle_step(step: str, func: Callable[[], None]) -> RunResult:
+def _handle_step(step: str, func: Callable[[], object]) -> RunResult:
     try:
         func()
         return RunResult(step=step, status="success")
@@ -39,13 +39,14 @@ def _handle_step(step: str, func: Callable[[], None]) -> RunResult:
         return RunResult(step=step, status="failed", message=str(exc))
 
 
-def run_crawl(config_path: Optional[str] = None) -> RunResult:
+def run_crawl(config_path: str | None = None) -> RunResult:
     """Run unified crawl step."""
     from src.crawlers.unified_crawler import UnifiedCrawler
-    return _handle_step("crawl", lambda: UnifiedCrawler(config_path).run())
+    crawler = UnifiedCrawler(config_path) if config_path is not None else UnifiedCrawler()
+    return _handle_step("crawl", lambda: crawler.run())
 
 
-def run_preprocess(batch_size: int = 100, limit: Optional[int] = None, config_path: Optional[str] = None) -> RunResult:
+def run_preprocess(batch_size: int = 100, limit: int | None = None, config_path: str | None = None) -> RunResult:
     """Run preprocessing step (deprecated: replaced by Bronze-to-Silver cleansing pipeline)."""
     msg = (
         "run_preprocess is deprecated and has no effect. "
@@ -56,34 +57,39 @@ def run_preprocess(batch_size: int = 100, limit: Optional[int] = None, config_pa
     return RunResult(step="preprocess", status="failed", message=msg)
 
 
-def run_extract_features(batch_size: int = 100, limit: Optional[int] = None, config_path: Optional[str] = None) -> RunResult:
+def run_extract_features(batch_size: int = 100, limit: int | None = None, config_path: str | None = None) -> RunResult:
     """Run ABSA feature extraction step (Gold Layer)."""
     from src.gold.absa_analyzer import GoldABSAAnalyzer
     return _handle_step("features", lambda: GoldABSAAnalyzer(config_path).process_batch(batch_size=batch_size, limit=limit))
 
 
-def run_action_analysis(batch_size: int = 100, limit: Optional[int] = None, config_path: Optional[str] = None) -> RunResult:
+def run_action_analysis(batch_size: int = 100, limit: int | None = None, config_path: str | None = None) -> RunResult:
     """Run actionability & LLM summary step (Gold Layer)."""
     from src.gold.action_analyzer import GoldActionAnalyzer
-    return _handle_step("action", lambda: GoldActionAnalyzer(config_path).process_batch(batch_size=batch_size, limit=limit))
+    analyzer = GoldActionAnalyzer(config_path) if config_path is not None else GoldActionAnalyzer()
+    return _handle_step("action", lambda: analyzer.process_batch(batch_size=batch_size, limit=limit))
 
 
 def run_generate_embeddings(
-    batch_size: int = 100, limit: Optional[int] = None, model_name: str = "text-embedding-3-small", config_path: Optional[str] = None
+    batch_size: int = 100, limit: int | None = None, model_name: str = "text-embedding-3-small", config_path: str | None = None
 ) -> RunResult:
     """Run embedding generation step (Gold Layer)."""
     from src.gold.embedding_generator import GoldEmbeddingGenerator
     return _handle_step(
         "embed",
-        lambda: GoldEmbeddingGenerator(model_name=model_name, config_path=config_path).process_batch(batch_size=batch_size, limit=limit),
+        lambda: (
+            GoldEmbeddingGenerator(model_name=model_name, config_path=config_path)
+            if config_path is not None
+            else GoldEmbeddingGenerator(model_name=model_name)
+        ).process_batch(batch_size=batch_size, limit=limit),
     )
 
 
 def run_gold(
     batch_size: int = 100,
-    limit: Optional[int] = None,
-    target_date: Optional[str] = None,
-    config_path: Optional[str] = None,
+    limit: int | None = None,
+    target_date: str | None = None,
+    config_path: str | None = None,
 ) -> RunResult:
     """Run Gold Layer orchestration step (embedding → ABSA → action analysis)."""
     from src.gold.orchestrator import GoldOrchestrator
@@ -110,10 +116,10 @@ def run_gold(
 
 
 def run_aggregate(
-    target_date: Optional[str] = None,
-    start_date: Optional[str] = None,
-    end_date: Optional[str] = None,
-    config_path: Optional[str] = None,
+    target_date: str | None = None,
+    start_date: str | None = None,
+    end_date: str | None = None,
+    config_path: str | None = None,
 ) -> RunResult:
     """Run Gold Layer aggregation step (fact tables + serving mart)."""
     from src.gold.aggregator import GoldAggregator
@@ -138,7 +144,8 @@ def run_aggregate(
             parsed_date = _parse_date_arg("target_date", target_date)
         except ValueError as exc:
             return RunResult(step="aggregate", status="failed", message=str(exc))
-        return _handle_step("aggregate", lambda: GoldAggregator(config_path).run(target_date=parsed_date))
+        aggregator = GoldAggregator(config_path) if config_path is not None else GoldAggregator()
+        return _handle_step("aggregate", lambda: aggregator.run(target_date=parsed_date))
 
     if start_date and end_date:
         try:
@@ -146,33 +153,75 @@ def run_aggregate(
             parsed_end = _parse_date_arg("end_date", end_date)
         except ValueError as exc:
             return RunResult(step="aggregate", status="failed", message=str(exc))
+        aggregator = GoldAggregator(config_path) if config_path is not None else GoldAggregator()
         return _handle_step(
             "aggregate",
-            lambda: GoldAggregator(config_path).run_range(
+            lambda: aggregator.run_range(
                 start_date=parsed_start,
                 end_date=parsed_end,
             ),
         )
 
-    return _handle_step("aggregate", lambda: GoldAggregator(config_path).run(target_date=_date.today()))
+    aggregator = GoldAggregator(config_path) if config_path is not None else GoldAggregator()
+    return _handle_step("aggregate", lambda: aggregator.run(target_date=_date.today()))
 
 
-def run_load(batch_size: int = 100, config_path: Optional[str] = None) -> RunResult:
+def run_post_aggregate_validation(
+    target_date: str,
+    config_path: str | None = None,
+) -> RunResult:
+    """Run post-aggregate DB readiness validation for a target date."""
+    from src.pipeline.post_aggregate_validation import PostAggregateValidator
+
+    try:
+        parsed_date = _parse_date_arg("target_date", target_date)
+    except ValueError as exc:
+        return RunResult(step="post_aggregate_validate", status="failed", message=str(exc))
+
+    try:
+        report = PostAggregateValidator(config_path).validate(parsed_date)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("post_aggregate_validate step failed")
+        return RunResult(step="post_aggregate_validate", status="failed", message=str(exc))
+
+    validations = report.as_dict()
+    if report.status != "success":
+        failed_checks = [
+            check.name
+            for check in report.checks
+            if check.severity == "failure" and not check.passed
+        ]
+        return RunResult(
+            step="post_aggregate_validate",
+            status="failed",
+            validations=validations,
+            message=f"Post-aggregate validation failed: {', '.join(failed_checks)}",
+        )
+
+    return RunResult(
+        step="post_aggregate_validate",
+        status="success",
+        validations=validations,
+    )
+
+
+def run_load(batch_size: int = 100, config_path: str | None = None) -> RunResult:
     """Run Parquet batch → DB load step."""
     from src.loaders.batch_loader import BatchLoader
-    return _handle_step("load", lambda: BatchLoader(config_path).load_pending_batches(limit=batch_size))
+    loader = BatchLoader(config_path) if config_path is not None else BatchLoader()
+    return _handle_step("load", lambda: loader.load_pending_batches(limit=batch_size))
 
 
 def run_steps(
-    steps: List[str],
+    steps: list[str],
     batch_size: int = 100,
-    limit: Optional[int] = None,
+    limit: int | None = None,
     model_name: str = "text-embedding-3-small",
-    config_path: Optional[str] = None,
-    target_date: Optional[str] = None,
-) -> List[RunResult]:
+    config_path: str | None = None,
+    target_date: str | None = None,
+) -> list[RunResult]:
     """Run multiple steps in sequence; stop on first failure."""
-    step_funcs: Dict[str, Callable[[], RunResult]] = {
+    step_funcs: dict[str, Callable[[], RunResult]] = {
         "crawl": lambda: run_crawl(config_path),
         "load": lambda: run_load(batch_size=batch_size, config_path=config_path),
         "preprocess": lambda: run_preprocess(batch_size=batch_size, limit=limit, config_path=config_path),
@@ -186,9 +235,17 @@ def run_steps(
             target_date=target_date,
         ),
         "aggregate": lambda: run_aggregate(config_path=config_path, target_date=target_date),
+        "post_aggregate_validate": lambda: run_post_aggregate_validation(
+            target_date=target_date or "",
+            config_path=config_path,
+        ),
+        "validate": lambda: run_post_aggregate_validation(
+            target_date=target_date or "",
+            config_path=config_path,
+        ),
     }
 
-    results: List[RunResult] = []
+    results: list[RunResult] = []
     for step in steps:
         if step not in step_funcs:
             results.append(RunResult(step=step, status="failed", message="unknown step"))

--- a/tests/test_airflow_dag_validation_wiring.py
+++ b/tests/test_airflow_dag_validation_wiring.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+DAG_PATH = Path(__file__).resolve().parents[1] / "dags" / "financial_review_pipeline.py"
+
+
+def test_airflow_dag_wires_post_aggregate_validation_after_gold_aggregate():
+    dag_source = DAG_PATH.read_text(encoding="utf-8")
+
+    assert 'task_id="post_aggregate_validate"' in dag_source
+    assert "--steps post_aggregate_validate --target-date {{ ds }}" in dag_source
+    assert "gold_aggregate\n    >> post_aggregate_validate" in dag_source
+    assert dag_source.index('task_id="gold_aggregate"') < dag_source.index(
+        'task_id="post_aggregate_validate"'
+    )

--- a/tests/test_airflow_dag_validation_wiring.py
+++ b/tests/test_airflow_dag_validation_wiring.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 
 
@@ -9,7 +10,7 @@ def test_airflow_dag_wires_post_aggregate_validation_after_gold_aggregate():
 
     assert 'task_id="post_aggregate_validate"' in dag_source
     assert "--steps post_aggregate_validate --target-date {{ ds }}" in dag_source
-    assert "gold_aggregate\n    >> post_aggregate_validate" in dag_source
+    assert re.search(r"gold_aggregate\s*>>\s*post_aggregate_validate", dag_source)
     assert dag_source.index('task_id="gold_aggregate"') < dag_source.index(
         'task_id="post_aggregate_validate"'
     )

--- a/tests/test_airflow_readiness_docs.py
+++ b/tests/test_airflow_readiness_docs.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+DOC_PATH = Path(__file__).resolve().parents[1] / "docs" / "airflow-continuous-load-readiness.md"
+
+
+def test_airflow_readiness_doc_explains_validation_policy_and_follow_up():
+    doc = DOC_PATH.read_text(encoding="utf-8")
+
+    required_markers = [
+        "## Contract boundary",
+        "## Warning vs failure policy",
+        "fresh_ingestion",
+        "warning",
+        "failure",
+        "post_aggregate_validate",
+        "PYTHONPATH=. uv run python -m src.pipeline.cli",
+        "## Follow-up: Metabase/Grafana",
+        "Metabase/Grafana readiness metrics dashboard",
+    ]
+    for marker in required_markers:
+        assert marker in doc

--- a/tests/test_pipeline_cli_validation.py
+++ b/tests/test_pipeline_cli_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import text
@@ -44,7 +45,9 @@ def test_pipeline_cli_post_aggregate_validate_exits_non_zero_for_required_failur
     test_db_schema,
     monkeypatch,
 ):
-    storage_path = "s3://reai-data/bronze/post-aggregate/cli-failure.parquet"
+    storage_path = (
+        f"s3://reai-data/bronze/post-aggregate/cli-failure-{uuid4()}.parquet"
+    )
     monkeypatch.setenv("DATABASE_URL", test_db_url)
     try:
         with test_db_engine.begin() as connection:

--- a/tests/test_pipeline_cli_validation.py
+++ b/tests/test_pipeline_cli_validation.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import text
+
+from src.pipeline import cli as pipeline_cli
+
+
+CLI_WARNING_TARGET_DATE = date(2026, 5, 18)
+CLI_FAILURE_TARGET_DATE = date(2026, 5, 19)
+
+
+def _target_datetime(target_date: date) -> datetime:
+    return datetime(target_date.year, target_date.month, target_date.day, 9, 30, tzinfo=timezone.utc)
+
+
+@pytest.mark.requires_db
+def test_pipeline_cli_post_aggregate_validate_exits_zero_for_warning_only(
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    assert (
+        pipeline_cli.main(
+            [
+                "--steps",
+                "post_aggregate_validate",
+                "--target-date",
+                CLI_WARNING_TARGET_DATE.isoformat(),
+            ]
+        )
+        == 0
+    )
+
+
+@pytest.mark.requires_db
+def test_pipeline_cli_post_aggregate_validate_exits_non_zero_for_required_failure(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    storage_path = "s3://reai-data/bronze/post-aggregate/cli-failure.parquet"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+    try:
+        with test_db_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO ingestion_batch (
+                        source_type,
+                        platform_app_id,
+                        app_name,
+                        storage_path,
+                        record_count,
+                        status,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (
+                        'APPSTORE',
+                        'post.aggregate.cli.failure',
+                        'Post Aggregate CLI Failure',
+                        :storage_path,
+                        1,
+                        'PENDING',
+                        :created_at,
+                        :created_at
+                    )
+                    """
+                ),
+                {
+                    "storage_path": storage_path,
+                    "created_at": _target_datetime(CLI_FAILURE_TARGET_DATE),
+                },
+            )
+
+        assert (
+            pipeline_cli.main(
+                [
+                    "--steps",
+                    "post_aggregate_validate",
+                    "--target-date",
+                    CLI_FAILURE_TARGET_DATE.isoformat(),
+                ]
+            )
+            == 1
+        )
+    finally:
+        with test_db_engine.begin() as connection:
+            connection.execute(
+                text("DELETE FROM ingestion_batch WHERE storage_path = :storage_path"),
+                {"storage_path": storage_path},
+            )

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock, patch
 
-from src.pipeline.steps import run_aggregate, run_gold
+from src.pipeline.steps import run_aggregate, run_gold, run_post_aggregate_validation, run_steps
 
 
 @patch("src.gold.aggregator.GoldAggregator")
@@ -96,3 +96,19 @@ def test_run_gold_returns_failed_result_for_empty_target_date():
 
     assert result.status == "failed"
     assert "YYYY-MM-DD" in result.message
+
+
+def test_run_post_aggregate_validation_returns_failed_result_for_invalid_target_date():
+    result = run_post_aggregate_validation(target_date="2025/01/15")
+
+    assert result.status == "failed"
+    assert "YYYY-MM-DD" in result.message
+
+
+def test_run_steps_supports_post_aggregate_validate_step_name():
+    results = run_steps(["post_aggregate_validate"], target_date="")
+
+    assert len(results) == 1
+    assert results[0].step == "post_aggregate_validate"
+    assert results[0].status == "failed"
+    assert "YYYY-MM-DD" in results[0].message

--- a/tests/test_post_aggregate_validation.py
+++ b/tests/test_post_aggregate_validation.py
@@ -1,0 +1,821 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+import pytest
+from sqlalchemy import text
+from uuid6 import uuid7
+
+from src.pipeline.steps import run_aggregate, run_post_aggregate_validation
+
+
+SUCCESS_TARGET_DATE = date(2026, 5, 10)
+WARNING_ONLY_TARGET_DATE = date(2026, 5, 11)
+PENDING_BATCH_TARGET_DATE = date(2026, 5, 12)
+FAILED_REVIEW_TARGET_DATE = date(2026, 5, 13)
+MISSING_MAPPING_TARGET_DATE = date(2026, 5, 14)
+ORPHAN_TARGET_DATE = date(2026, 5, 15)
+MART_MISSING_TARGET_DATE = date(2026, 5, 16)
+COUNT_MISMATCH_TARGET_DATE = date(2026, 5, 17)
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_passes_for_valid_target_date_marts(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    service_id = uuid7()
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = f"post-aggregate-success-{review_id}"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    _cleanup_probe(
+        test_db_engine,
+        target_date=SUCCESS_TARGET_DATE,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    try:
+        with test_db_engine.begin() as connection:
+            _insert_complete_upstream_rows(
+                connection,
+                target_date=SUCCESS_TARGET_DATE,
+                service_id=service_id,
+                app_id=app_id,
+                review_id=review_id,
+                platform_review_id=platform_review_id,
+                include_metadata=True,
+                include_ingestion_batch=True,
+            )
+
+        aggregate_result = run_aggregate(target_date=SUCCESS_TARGET_DATE.isoformat())
+        assert aggregate_result.status == "success", aggregate_result.message
+
+        result = run_post_aggregate_validation(target_date=SUCCESS_TARGET_DATE.isoformat())
+
+        assert result.status == "success", result.message
+        assert result.validations["warnings"] == []
+        _assert_check(result.validations, "mart_freshness", passed=True)
+        _assert_check(result.validations, "mart_count_consistency", passed=True)
+    finally:
+        _cleanup_probe(
+            test_db_engine,
+            target_date=SUCCESS_TARGET_DATE,
+            service_id=service_id,
+            app_id=app_id,
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+        )
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_treats_zero_fresh_ingestion_as_warning_only(
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    result = run_post_aggregate_validation(target_date=WARNING_ONLY_TARGET_DATE.isoformat())
+
+    assert result.status == "success", result.message
+    assert result.validations["warnings"] == ["fresh_ingestion"]
+    _assert_check(result.validations, "fresh_ingestion", passed=False)
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_fails_when_target_date_batch_is_pending(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    storage_path = "s3://reai-data/bronze/post-aggregate/pending.parquet"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+    try:
+        with test_db_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    INSERT INTO ingestion_batch (
+                        source_type,
+                        platform_app_id,
+                        app_name,
+                        storage_path,
+                        record_count,
+                        status,
+                        created_at,
+                        updated_at
+                    )
+                    VALUES (
+                        'APPSTORE',
+                        'post.aggregate.pending',
+                        'Post Aggregate Pending',
+                        :storage_path,
+                        1,
+                        'PENDING',
+                        :created_at,
+                        :created_at
+                    )
+                    """
+                ),
+                {
+                    "storage_path": storage_path,
+                    "created_at": _target_datetime(PENDING_BATCH_TARGET_DATE),
+                },
+            )
+
+        result = run_post_aggregate_validation(target_date=PENDING_BATCH_TARGET_DATE.isoformat())
+
+        assert result.status == "failed"
+        check = _assert_check(result.validations, "batch_state", passed=False)
+        assert check["metrics"]["by_status"] == {"PENDING": 1}
+    finally:
+        with test_db_engine.begin() as connection:
+            connection.execute(
+                text("DELETE FROM ingestion_batch WHERE storage_path = :storage_path"),
+                {"storage_path": storage_path},
+            )
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_fails_retry_exhausted_review_state(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    service_id = uuid7()
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = f"post-aggregate-failed-{review_id}"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    _cleanup_probe(
+        test_db_engine,
+        target_date=FAILED_REVIEW_TARGET_DATE,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    try:
+        with test_db_engine.begin() as connection:
+            _insert_app_context(
+                connection,
+                service_id=service_id,
+                app_id=app_id,
+                include_metadata=True,
+                target_date=FAILED_REVIEW_TARGET_DATE,
+            )
+            _insert_review_master_index(
+                connection,
+                target_date=FAILED_REVIEW_TARGET_DATE,
+                service_id=service_id,
+                app_id=app_id,
+                review_id=review_id,
+                platform_review_id=platform_review_id,
+                processing_status="FAILED",
+                retry_count=3,
+            )
+
+        result = run_post_aggregate_validation(target_date=FAILED_REVIEW_TARGET_DATE.isoformat())
+
+        assert result.status == "failed"
+        check = _assert_check(result.validations, "review_state", passed=False)
+        assert check["metrics"]["retry_exhausted_failed_count"] == 1
+    finally:
+        _cleanup_probe(
+            test_db_engine,
+            target_date=FAILED_REVIEW_TARGET_DATE,
+            service_id=service_id,
+            app_id=app_id,
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+        )
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_fails_missing_service_metadata_mapping(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    service_id = uuid7()
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = f"post-aggregate-mapping-{review_id}"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    _cleanup_probe(
+        test_db_engine,
+        target_date=MISSING_MAPPING_TARGET_DATE,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    try:
+        with test_db_engine.begin() as connection:
+            _insert_complete_upstream_rows(
+                connection,
+                target_date=MISSING_MAPPING_TARGET_DATE,
+                service_id=service_id,
+                app_id=app_id,
+                review_id=review_id,
+                platform_review_id=platform_review_id,
+                include_metadata=False,
+                include_ingestion_batch=True,
+            )
+
+        result = run_post_aggregate_validation(target_date=MISSING_MAPPING_TARGET_DATE.isoformat())
+
+        assert result.status == "failed"
+        check = _assert_check(result.validations, "metadata_mapping", passed=False)
+        assert check["metrics"]["missing_active_mapping"] == 1
+    finally:
+        _cleanup_probe(
+            test_db_engine,
+            target_date=MISSING_MAPPING_TARGET_DATE,
+            service_id=service_id,
+            app_id=app_id,
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+        )
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_fails_analyzed_orphan_rows(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    service_id = uuid7()
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = f"post-aggregate-orphan-{review_id}"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    _cleanup_probe(
+        test_db_engine,
+        target_date=ORPHAN_TARGET_DATE,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    try:
+        with test_db_engine.begin() as connection:
+            _insert_app_context(
+                connection,
+                service_id=service_id,
+                app_id=app_id,
+                include_metadata=True,
+                target_date=ORPHAN_TARGET_DATE,
+            )
+            _insert_review_master_index(
+                connection,
+                target_date=ORPHAN_TARGET_DATE,
+                service_id=service_id,
+                app_id=app_id,
+                review_id=review_id,
+                platform_review_id=platform_review_id,
+            )
+
+        result = run_post_aggregate_validation(target_date=ORPHAN_TARGET_DATE.isoformat())
+
+        assert result.status == "failed"
+        check = _assert_check(result.validations, "orphan_integrity", passed=False)
+        assert check["metrics"] == {
+            "missing_action_analysis": 1,
+            "missing_app_review": 1,
+            "missing_preprocessed": 1,
+            "missing_aspects": 1,
+        }
+    finally:
+        _cleanup_probe(
+            test_db_engine,
+            target_date=ORPHAN_TARGET_DATE,
+            service_id=service_id,
+            app_id=app_id,
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+        )
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_fails_when_marts_are_missing_for_analyzed_upstream(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    service_id = uuid7()
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = f"post-aggregate-mart-missing-{review_id}"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    _cleanup_probe(
+        test_db_engine,
+        target_date=MART_MISSING_TARGET_DATE,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    try:
+        with test_db_engine.begin() as connection:
+            _insert_complete_upstream_rows(
+                connection,
+                target_date=MART_MISSING_TARGET_DATE,
+                service_id=service_id,
+                app_id=app_id,
+                review_id=review_id,
+                platform_review_id=platform_review_id,
+                include_metadata=True,
+                include_ingestion_batch=True,
+            )
+
+        result = run_post_aggregate_validation(target_date=MART_MISSING_TARGET_DATE.isoformat())
+
+        assert result.status == "failed"
+        check = _assert_check(result.validations, "mart_freshness", passed=False)
+        assert check["metrics"]["analyzed_count"] == 1
+        assert set(check["metrics"]["row_counts"]) == {
+            "fact_service_review_daily",
+            "fact_service_aspect_daily",
+            "fact_category_radar_scores",
+            "srv_daily_review_list",
+        }
+    finally:
+        _cleanup_probe(
+            test_db_engine,
+            target_date=MART_MISSING_TARGET_DATE,
+            service_id=service_id,
+            app_id=app_id,
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+        )
+
+
+@pytest.mark.requires_db
+def test_post_aggregate_validation_fails_mart_count_mismatch(
+    test_db_engine,
+    test_db_url,
+    test_db_schema,
+    monkeypatch,
+):
+    service_id = uuid7()
+    app_id = uuid7()
+    review_id = uuid7()
+    platform_review_id = f"post-aggregate-count-mismatch-{review_id}"
+    monkeypatch.setenv("DATABASE_URL", test_db_url)
+
+    _cleanup_probe(
+        test_db_engine,
+        target_date=COUNT_MISMATCH_TARGET_DATE,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    try:
+        with test_db_engine.begin() as connection:
+            _insert_complete_upstream_rows(
+                connection,
+                target_date=COUNT_MISMATCH_TARGET_DATE,
+                service_id=service_id,
+                app_id=app_id,
+                review_id=review_id,
+                platform_review_id=platform_review_id,
+                include_metadata=True,
+                include_ingestion_batch=True,
+            )
+
+        aggregate_result = run_aggregate(target_date=COUNT_MISMATCH_TARGET_DATE.isoformat())
+        assert aggregate_result.status == "success", aggregate_result.message
+        with test_db_engine.begin() as connection:
+            connection.execute(
+                text(
+                    """
+                    UPDATE fact_service_review_daily
+                    SET total_review_cnt = 99
+                    WHERE date = :target_date
+                      AND service_id = :service_id
+                    """
+                ),
+                {"target_date": COUNT_MISMATCH_TARGET_DATE, "service_id": service_id},
+            )
+
+        result = run_post_aggregate_validation(target_date=COUNT_MISMATCH_TARGET_DATE.isoformat())
+
+        assert result.status == "failed"
+        check = _assert_check(result.validations, "mart_count_consistency", passed=False)
+        assert check["metrics"]["expected_analyzed_review_count"] == 1
+        assert check["metrics"]["fact_service_review_daily_total"] == 99
+    finally:
+        _cleanup_probe(
+            test_db_engine,
+            target_date=COUNT_MISMATCH_TARGET_DATE,
+            service_id=service_id,
+            app_id=app_id,
+            review_id=review_id,
+            platform_review_id=platform_review_id,
+        )
+
+
+def _assert_check(validations, check_name: str, *, passed: bool):
+    check = next(check for check in validations["checks"] if check["name"] == check_name)
+    assert check["passed"] is passed
+    return check
+
+
+def _target_datetime(target_date: date) -> datetime:
+    return datetime(target_date.year, target_date.month, target_date.day, 9, 30, tzinfo=timezone.utc)
+
+
+def _insert_app_context(
+    connection,
+    *,
+    service_id,
+    app_id,
+    include_metadata: bool,
+    target_date: date,
+) -> None:
+    connection.execute(
+        text(
+            """
+            INSERT INTO app_service (service_id, service_name)
+            VALUES (:service_id, 'Post Aggregate Validation Bank')
+            """
+        ),
+        {"service_id": service_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO apps (app_id, platform_app_id, platform_type, name)
+            VALUES (:app_id, :platform_app_id, 'APPSTORE', 'Post Aggregate Validation App')
+            """
+        ),
+        {"app_id": app_id, "platform_app_id": f"post.aggregate.{app_id}"},
+    )
+    if include_metadata:
+        connection.execute(
+            text(
+                """
+                INSERT INTO app_metadata (
+                    app_id,
+                    service_id,
+                    app_type,
+                    valid_from,
+                    valid_to,
+                    is_active
+                )
+                VALUES (
+                    :app_id,
+                    :service_id,
+                    'CONSUMER',
+                    :valid_from,
+                    NULL,
+                    TRUE
+                )
+                """
+            ),
+            {
+                "app_id": app_id,
+                "service_id": service_id,
+                "valid_from": target_date,
+            },
+        )
+
+
+def _insert_review_master_index(
+    connection,
+    *,
+    target_date: date,
+    service_id,
+    app_id,
+    review_id,
+    platform_review_id: str,
+    processing_status: str = "ANALYZED",
+    retry_count: int = 0,
+) -> None:
+    reviewed_at = _target_datetime(target_date)
+    connection.execute(
+        text(
+            """
+            INSERT INTO review_master_index (
+                review_id,
+                app_id,
+                service_id,
+                platform_review_id,
+                platform_type,
+                review_created_at,
+                ingested_at,
+                processing_status,
+                parquet_written_at,
+                storage_path,
+                retry_count,
+                is_active,
+                is_reply
+            )
+            VALUES (
+                :review_id,
+                :app_id,
+                :service_id,
+                :platform_review_id,
+                'APPSTORE',
+                :reviewed_at,
+                :reviewed_at,
+                :processing_status,
+                :reviewed_at,
+                :storage_path,
+                :retry_count,
+                TRUE,
+                FALSE
+            )
+            """
+        ),
+        {
+            "review_id": review_id,
+            "app_id": app_id,
+            "service_id": service_id,
+            "platform_review_id": platform_review_id,
+            "reviewed_at": reviewed_at,
+            "processing_status": processing_status,
+            "storage_path": f"s3://reai-data/bronze/post-aggregate/{review_id}.parquet",
+            "retry_count": retry_count,
+        },
+    )
+
+
+def _insert_complete_upstream_rows(
+    connection,
+    *,
+    target_date: date,
+    service_id,
+    app_id,
+    review_id,
+    platform_review_id: str,
+    include_metadata: bool,
+    include_ingestion_batch: bool,
+) -> None:
+    reviewed_at = _target_datetime(target_date)
+    _insert_app_context(
+        connection,
+        service_id=service_id,
+        app_id=app_id,
+        include_metadata=include_metadata,
+        target_date=target_date,
+    )
+    if include_ingestion_batch:
+        connection.execute(
+            text(
+                """
+                INSERT INTO ingestion_batch (
+                    source_type,
+                    platform_app_id,
+                    app_name,
+                    storage_path,
+                    record_count,
+                    status,
+                    created_at,
+                    updated_at,
+                    loaded_at
+                )
+                VALUES (
+                    'APPSTORE',
+                    :platform_app_id,
+                    'Post Aggregate Validation App',
+                    :storage_path,
+                    1,
+                    'LOADED',
+                    :reviewed_at,
+                    :reviewed_at,
+                    :reviewed_at
+                )
+                """
+            ),
+            {
+                "platform_app_id": f"post.aggregate.{app_id}",
+                "storage_path": f"s3://reai-data/bronze/post-aggregate/batch-{review_id}.parquet",
+                "reviewed_at": reviewed_at,
+            },
+        )
+    _insert_review_master_index(
+        connection,
+        target_date=target_date,
+        service_id=service_id,
+        app_id=app_id,
+        review_id=review_id,
+        platform_review_id=platform_review_id,
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO app_reviews (
+                review_id,
+                app_id,
+                platform_type,
+                country_code,
+                platform_review_id,
+                reviewer_name,
+                review_text,
+                rating,
+                app_version,
+                reviewed_at,
+                is_reply,
+                reply_comment
+            )
+            VALUES (
+                :review_id,
+                :app_id,
+                'APPSTORE',
+                'kr',
+                :platform_review_id,
+                'post-aggregate-reviewer',
+                'login is slow but usable',
+                4,
+                '1.0.0',
+                :reviewed_at,
+                FALSE,
+                NULL
+            )
+            """
+        ),
+        {
+            "review_id": review_id,
+            "app_id": app_id,
+            "platform_review_id": platform_review_id,
+            "reviewed_at": reviewed_at,
+        },
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO reviews_preprocessed (
+                review_id,
+                app_review_id,
+                platform_review_id,
+                refined_text
+            )
+            VALUES (
+                :review_id,
+                :review_id,
+                :platform_review_id,
+                'login is slow but usable'
+            )
+            """
+        ),
+        {"review_id": review_id, "platform_review_id": platform_review_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO review_action_analysis (
+                review_id,
+                is_action_required,
+                action_confidence_score,
+                trigger_reason,
+                is_attention_required,
+                is_verified,
+                analyzed_at,
+                review_summary
+            )
+            VALUES (
+                :review_id,
+                TRUE,
+                0.91,
+                'slow login',
+                TRUE,
+                TRUE,
+                :reviewed_at,
+                'Login is slow but still usable'
+            )
+            """
+        ),
+        {"review_id": review_id, "reviewed_at": reviewed_at},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO review_aspects (
+                review_id,
+                keyword,
+                sentiment_score,
+                category
+            )
+            VALUES
+                (:review_id, 'login', 0.75, 'USABILITY'),
+                (:review_id, 'speed', 0.65, 'SPEED')
+            """
+        ),
+        {"review_id": review_id},
+    )
+    connection.execute(
+        text(
+            """
+            INSERT INTO reviews_assigned (
+                review_id,
+                assigned_dept,
+                assignment_reason,
+                confidence,
+                is_failed,
+                try_number
+            )
+            VALUES (
+                :review_id,
+                ARRAY['CX', 'APP'],
+                'post aggregate validation seed',
+                0.88,
+                FALSE,
+                1
+            )
+            """
+        ),
+        {"review_id": review_id},
+    )
+
+
+def _cleanup_probe(
+    test_db_engine,
+    *,
+    target_date: date,
+    service_id,
+    app_id,
+    review_id,
+    platform_review_id: str,
+) -> None:
+    partition_name = f"srv_daily_review_list_{target_date.strftime('%Y_%m_%d')}"
+    with test_db_engine.begin() as connection:
+        connection.execute(text(f"DROP TABLE IF EXISTS public.{partition_name}"))
+        for table_name in (
+            "fact_service_review_daily",
+            "fact_service_aspect_daily",
+            "fact_category_radar_scores",
+        ):
+            connection.execute(
+                text(
+                    f"""
+                    DELETE FROM {table_name}
+                    WHERE service_id = :service_id
+                      AND date = :target_date
+                    """
+                ),
+                {"service_id": service_id, "target_date": target_date},
+            )
+        connection.execute(
+            text("DELETE FROM reviews_assigned WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text("DELETE FROM review_action_analysis WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text("DELETE FROM review_aspects WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text("DELETE FROM reviews_preprocessed WHERE review_id = :review_id"),
+            {"review_id": review_id},
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM app_reviews
+                WHERE review_id = :review_id
+                   OR platform_review_id = :platform_review_id
+                """
+            ),
+            {"review_id": review_id, "platform_review_id": platform_review_id},
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM review_master_index
+                WHERE review_id = :review_id
+                   OR platform_review_id = :platform_review_id
+                """
+            ),
+            {"review_id": review_id, "platform_review_id": platform_review_id},
+        )
+        connection.execute(
+            text("DELETE FROM ingestion_batch WHERE storage_path LIKE :storage_path_pattern"),
+            {"storage_path_pattern": f"%{review_id}%"},
+        )
+        connection.execute(text("DELETE FROM app_metadata WHERE app_id = :app_id"), {"app_id": app_id})
+        connection.execute(text("DELETE FROM apps WHERE app_id = :app_id"), {"app_id": app_id})
+        connection.execute(
+            text("DELETE FROM app_service WHERE service_id = :service_id"),
+            {"service_id": service_id},
+        )

--- a/tests/test_post_aggregate_validation.py
+++ b/tests/test_post_aggregate_validation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import date, datetime, timezone
 
 import pytest
@@ -59,9 +60,11 @@ def test_post_aggregate_validation_passes_for_valid_target_date_marts(
         result = run_post_aggregate_validation(target_date=SUCCESS_TARGET_DATE.isoformat())
 
         assert result.status == "success", result.message
-        assert result.validations["warnings"] == []
-        _assert_check(result.validations, "mart_freshness", passed=True)
-        _assert_check(result.validations, "mart_count_consistency", passed=True)
+        validations = result.validations
+        assert validations is not None
+        assert validations["warnings"] == []
+        _assert_check(validations, "mart_freshness", passed=True)
+        _assert_check(validations, "mart_count_consistency", passed=True)
     finally:
         _cleanup_probe(
             test_db_engine,
@@ -84,8 +87,10 @@ def test_post_aggregate_validation_treats_zero_fresh_ingestion_as_warning_only(
     result = run_post_aggregate_validation(target_date=WARNING_ONLY_TARGET_DATE.isoformat())
 
     assert result.status == "success", result.message
-    assert result.validations["warnings"] == ["fresh_ingestion"]
-    _assert_check(result.validations, "fresh_ingestion", passed=False)
+    validations = result.validations
+    assert validations is not None
+    assert validations["warnings"] == ["fresh_ingestion"]
+    _assert_check(validations, "fresh_ingestion", passed=False)
 
 
 @pytest.mark.requires_db
@@ -756,23 +761,42 @@ def _cleanup_probe(
     platform_review_id: str,
 ) -> None:
     partition_name = f"srv_daily_review_list_{target_date.strftime('%Y_%m_%d')}"
+    if not re.fullmatch(r"srv_daily_review_list_\d{4}_\d{2}_\d{2}", partition_name):
+        raise ValueError(f"Unexpected partition name: {partition_name}")
+
+    mart_params = {"service_id": service_id, "target_date": target_date}
     with test_db_engine.begin() as connection:
-        connection.execute(text(f"DROP TABLE IF EXISTS public.{partition_name}"))
-        for table_name in (
-            "fact_service_review_daily",
-            "fact_service_aspect_daily",
-            "fact_category_radar_scores",
-        ):
-            connection.execute(
-                text(
-                    f"""
-                    DELETE FROM {table_name}
-                    WHERE service_id = :service_id
-                      AND date = :target_date
-                    """
-                ),
-                {"service_id": service_id, "target_date": target_date},
-            )
+        connection.execute(text(f'DROP TABLE IF EXISTS public."{partition_name}"'))
+        connection.execute(
+            text(
+                """
+                DELETE FROM fact_service_review_daily
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                """
+            ),
+            mart_params,
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM fact_service_aspect_daily
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                """
+            ),
+            mart_params,
+        )
+        connection.execute(
+            text(
+                """
+                DELETE FROM fact_category_radar_scores
+                WHERE service_id = :service_id
+                  AND date = :target_date
+                """
+            ),
+            mart_params,
+        )
         connection.execute(
             text("DELETE FROM reviews_assigned WHERE review_id = :review_id"),
             {"review_id": review_id},


### PR DESCRIPTION
## Summary
- Add `post_aggregate_validate` after `gold_aggregate` in the Airflow DAG.
- Validate target-date DB readiness from persisted tables before considering the DAG successful.
- Keep zero fresh ingestion as warning/report only; fail on state transition, metadata mapping, orphan integrity, mart freshness/count, and mart quality issues.
- Document the readiness contract and follow-up dashboard scope.

## Verification
- `PYTHONPATH=. uv run pytest -q`
  - `351 passed, 8 warnings`
- `basedpyright --level error src/pipeline/post_aggregate_validation.py src/pipeline/steps.py src/pipeline/cli.py dags/financial_review_pipeline.py`
  - `0 errors, 0 warnings, 0 notes`
- `git diff --check`

## Not tested
- Deployed Airflow scheduler/webserver DAG run.
- Airflow Web UI confirmation in staging/production.

## Operational notes
- This repo's compose files do not define Airflow webserver/scheduler services, so Web UI verification should happen in the deployed or staging Airflow environment.
- Metabase/Grafana dashboards remain a follow-up item, not part of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added post-aggregate validation step that automatically verifies data quality after aggregation, checking for freshness, processing state, mapping completeness, referential integrity, and consistency across data marts

* **Documentation**
  * Published operational readiness guide detailing validation policies, success and failure criteria, local reproduction methods, and dashboard follow-up actions

* **Tests**
  * Added validation test suite covering success and failure scenarios with comprehensive edge-case coverage

<!-- end of auto-generated comment: release notes by coderabbit.ai -->