### PR TITLE
[codex] Fix ABSA orphan integrity for short live reviews

### DIFF
--- a/src/gold/absa_analyzer.py
+++ b/src/gold/absa_analyzer.py
@@ -71,7 +71,9 @@ _ADV_WEIGHTS: Dict[str, float] = {
 
 # 부정어
 _NEGATION_WORDS = {"안", "못", "없", "아니", "않"}
-_COMPACT_NEGATION_PREFIXES = ("안", "못", "없", "아니", "않")
+_COMPACT_NEGATION_PREFIXES = tuple(
+    sorted(_NEGATION_WORDS, key=len, reverse=True)
+)
 
 # 키워드별 컨텍스트 윈도우 크기 (±N 토큰)
 _CONTEXT_WINDOW: int = 3
@@ -262,7 +264,7 @@ class GoldABSAAnalyzer:
                         result.append((noun, idx, idx + len(noun)))
                 if result:
                     return result
-                self.logger.info("Okt returned no usable keywords — fallback to dict match")
+                self.logger.debug("Okt returned no usable keywords — fallback to dict match")
             except Exception as e:
                 self.logger.warning(f"Okt.nouns failed: {e} — fallback to dict match")
 

--- a/src/gold/absa_analyzer.py
+++ b/src/gold/absa_analyzer.py
@@ -51,8 +51,9 @@ from src.utils.logger import get_logger
 _SENTIMENT_DICT: Dict[str, float] = {
     # 긍정
     "편리": 0.85, "편의": 0.80, "빠르": 0.80, "간편": 0.85,
-    "좋": 0.80, "훌륭": 0.90, "만족": 0.85, "추천": 0.85,
-    "쉽": 0.80, "깔끔": 0.75, "안정": 0.80, "친절": 0.80,
+    "좋": 0.80, "굿": 0.80, "훌륭": 0.90, "만족": 0.85, "추천": 0.85,
+    "쉽": 0.80, "편하": 0.80, "깔끔": 0.75, "안정": 0.80, "친절": 0.80,
+    "감사": 0.85,
     "개선": 0.70, "업데이트": 0.65, "해결": 0.75,
     # 부정
     "불편": 0.20, "느리": 0.20, "오류": 0.10, "버그": 0.10,
@@ -70,6 +71,7 @@ _ADV_WEIGHTS: Dict[str, float] = {
 
 # 부정어
 _NEGATION_WORDS = {"안", "못", "없", "아니", "않"}
+_COMPACT_NEGATION_PREFIXES = ("안", "못", "없", "아니", "않")
 
 # 키워드별 컨텍스트 윈도우 크기 (±N 토큰)
 _CONTEXT_WINDOW: int = 3
@@ -80,7 +82,7 @@ _CONTEXT_WINDOW: int = 3
 _CATEGORY_KEYWORDS: Dict[CategoryType, List[str]] = {
     CategoryType.USABILITY: [
         "사용", "편리", "편의", "인터페이스", "UI", "UX", "메뉴",
-        "기능", "조작", "접근", "쉽", "어렵", "복잡", "간편",
+        "기능", "조작", "접근", "쉽", "어렵", "복잡", "간편", "편하",
     ],
     CategoryType.STABILITY: [
         "오류", "버그", "에러", "강제종료", "팅김", "먹통", "충돌",
@@ -138,18 +140,18 @@ class GoldABSAAnalyzer:
 
             preprocessed = session.get(ReviewPreprocessed, review_id)
             if preprocessed is None:
-                self.logger.warning(f"[{review_id}] No preprocessed record — skip")
-                return True
+                self.logger.warning(f"[{review_id}] No preprocessed record")
+                return False
             if not preprocessed.refined_text:
-                self.logger.warning(f"[{review_id}] No refined_text — skip")
-                rmi = session.get(ReviewMasterIndex, review_id)
-                if rmi is not None:
-                    rmi.processing_status = ProcessingStatusType.ANALYZED
-                return True
+                self.logger.warning(f"[{review_id}] No refined_text")
+                return False
 
             try:
                 with session.begin_nested():
                     aspects = self._analyze(session, review_id, preprocessed.refined_text)
+                    if not aspects:
+                        self.logger.warning(f"[{review_id}] No ABSA aspects extracted")
+                        return False
                     session.add_all(aspects)
                     rmi = session.get(ReviewMasterIndex, review_id)
                     if rmi is not None:
@@ -219,7 +221,7 @@ class GoldABSAAnalyzer:
         aspects: List[ReviewAspect] = []
         for keyword, kw_start, kw_end in keywords_with_spans:
             context = self._local_context(text, kw_start)
-            has_negation = self._has_negation(context)
+            has_negation = self._has_negation(context, keyword=keyword)
             adv_weight = self._get_adv_weight(context)
 
             s_base = _SENTIMENT_DICT.get(keyword, 0.5)
@@ -258,10 +260,16 @@ class GoldABSAAnalyzer:
                     idx = text.find(noun)
                     if idx != -1:
                         result.append((noun, idx, idx + len(noun)))
-                return result
+                if result:
+                    return result
+                self.logger.info("Okt returned no usable keywords — fallback to dict match")
             except Exception as e:
                 self.logger.warning(f"Okt.nouns failed: {e} — fallback to dict match")
 
+        return self._dict_match_keywords_with_spans(text)
+
+    def _dict_match_keywords_with_spans(self, text: str) -> List[Tuple[str, int, int]]:
+        """사전 기반으로 키워드와 문자 span을 추출한다."""
         # Fallback: longest-first non-overlapping span matching
         # (prevents short stems like "안정" from matching inside "불안정한")
         candidates = sorted(
@@ -308,10 +316,18 @@ class GoldABSAAnalyzer:
         w_end = min(len(tokens), kw_token_idx + _CONTEXT_WINDOW + 1)
         return " ".join(tokens[w_start:w_end])
 
-    def _has_negation(self, text: str) -> bool:
+    def _has_negation(self, text: str, keyword: Optional[str] = None) -> bool:
         """텍스트에 부정어 포함 여부."""
         tokens = text.split()
-        return any(token in _NEGATION_WORDS for token in tokens)
+        for token in tokens:
+            if token in _NEGATION_WORDS:
+                return True
+            if keyword and any(
+                token.startswith(f"{prefix}{keyword}")
+                for prefix in _COMPACT_NEGATION_PREFIXES
+            ):
+                return True
+        return False
 
     def _get_adv_weight(self, text: str) -> float:
         """텍스트에서 가장 강한 부사 가중치 반환. 없으면 1.0."""

--- a/src/gold/action_analyzer.py
+++ b/src/gold/action_analyzer.py
@@ -166,7 +166,7 @@ class GoldActionAnalyzer:
             with session.begin_nested():
                 record = self._build_record(session, review_id)
                 if record is None:
-                    return True  # 데이터 부족 → skip
+                    return False  # 필수 upstream 데이터 부족 → ANALYZED 전환 금지
                 session.merge(record)
         except Exception as exc:
             self.logger.error(f"[{review_id}] ActionAnalyzer 실패: {exc}")
@@ -221,7 +221,7 @@ class GoldActionAnalyzer:
         from src.models.review import Review as AppReview
         rmi = session.get(ReviewMasterIndex, review_id)
         if rmi is None:
-            self.logger.warning(f"[{review_id}] ReviewMasterIndex 없음 — skip")
+            self.logger.warning(f"[{review_id}] ReviewMasterIndex 없음")
             return None
 
         app_review = (
@@ -240,7 +240,7 @@ class GoldActionAnalyzer:
 
         preprocessed = session.get(ReviewPreprocessed, review_id)
         if preprocessed is None or not preprocessed.refined_text:
-            self.logger.warning(f"[{review_id}] refined_text 없음 — skip")
+            self.logger.warning(f"[{review_id}] refined_text 없음")
             return None
 
         text = preprocessed.refined_text

--- a/tests/test_gold_absa_analyzer.py
+++ b/tests/test_gold_absa_analyzer.py
@@ -8,7 +8,6 @@ Coverage:
 - process_batch(): standalone batch with DB
 """
 
-import math
 import pytest
 from unittest.mock import MagicMock, patch
 from uuid6 import uuid7
@@ -18,6 +17,8 @@ from src.gold.absa_analyzer import (
     _cosine_similarity,
     _SENTIMENT_DICT,
     _CATEGORY_KEYWORDS,
+    _COMPACT_NEGATION_PREFIXES,
+    _NEGATION_WORDS,
 )
 from src.models.enums import CategoryType, ProcessingStatusType
 from src.models.review_aspects import ReviewAspect
@@ -217,6 +218,10 @@ class TestKeywordExtraction:
         analyzer = _make_analyzer(okt_mock=okt_mock)
         keywords = analyzer._extract_keywords("앱 좋아요")
         assert "좋" in keywords
+        analyzer.logger.debug.assert_called_once_with(
+            "Okt returned no usable keywords — fallback to dict match"
+        )
+        analyzer.logger.info.assert_not_called()
 
     @pytest.mark.parametrize(
         ("text", "expected_keyword"),
@@ -240,6 +245,9 @@ class TestKeywordExtraction:
 class TestNegationAdverb:
     def setup_method(self):
         self.analyzer = _make_analyzer()
+
+    def test_compact_negation_prefixes_derive_from_negation_words(self):
+        assert set(_COMPACT_NEGATION_PREFIXES) == _NEGATION_WORDS
 
     def test_has_negation_안(self):
         assert self.analyzer._has_negation("안 돼요") is True

--- a/tests/test_gold_absa_analyzer.py
+++ b/tests/test_gold_absa_analyzer.py
@@ -4,7 +4,7 @@ Coverage:
 - Sentiment score calculation (S_final = S_base × W_adv, negation inversion)
 - Keyword extraction (dict-match fallback, KoNLPy unavailable)
 - Category mapping (rule-based 1st, vector similarity 2nd)
-- process(): single-record happy path, skip-if-already-analyzed, skip-if-no-text
+- process(): single-record happy path, skip-if-already-analyzed, required-row failures
 - process_batch(): standalone batch with DB
 """
 
@@ -210,6 +210,28 @@ class TestKeywordExtraction:
         assert "편리" in keywords
         assert "빠르" in keywords
 
+    def test_okt_empty_result_falls_back_to_dict(self):
+        """KoNLPy가 짧은 활용형을 놓쳐도 사전 매칭으로 보완한다."""
+        okt_mock = MagicMock()
+        okt_mock.nouns.return_value = []
+        analyzer = _make_analyzer(okt_mock=okt_mock)
+        keywords = analyzer._extract_keywords("앱 좋아요")
+        assert "좋" in keywords
+
+    @pytest.mark.parametrize(
+        ("text", "expected_keyword"),
+        [
+            ("굿", "굿"),
+            ("편하게", "편하"),
+            ("감사합니다", "감사"),
+            ("만족스럽습니다", "만족"),
+        ],
+    )
+    def test_common_short_feedback_extracts_keyword(self, text, expected_keyword):
+        """짧은 실사용 리뷰도 aspect row 생성에 필요한 키워드를 추출한다."""
+        keywords = _make_analyzer()._extract_keywords(text)
+        assert expected_keyword in keywords
+
 
 # ─────────────────────────────────────────────
 # D. Negation & adverb detection
@@ -224,6 +246,9 @@ class TestNegationAdverb:
 
     def test_has_negation_못(self):
         assert self.analyzer._has_negation("못 써요") is True
+
+    def test_has_compact_negation_안좋음(self):
+        assert self.analyzer._has_negation("안좋음", keyword="좋") is True
 
     def test_no_negation(self):
         assert self.analyzer._has_negation("잘 돼요") is False
@@ -244,6 +269,15 @@ class TestNegationAdverb:
     def test_no_false_positive_negation_in_안정(self):
         """'안정적' 텍스트에서 '안'을 부정어로 오탐하지 않아야 함."""
         assert self.analyzer._has_negation("앱이 안정적이고 빠릅니다") is False
+
+    def test_no_false_positive_negation_in_안녕하세요(self):
+        """인사말의 '안'을 가까운 감성 키워드의 부정어로 오탐하지 않아야 함."""
+        assert self.analyzer._has_negation("안녕하세요 좋은 앱입니다", keyword="좋") is False
+
+    def test_compact_negation_inverts_sentiment(self):
+        aspects = self.analyzer._analyze(MagicMock(), uuid7(), "안좋음")
+        kw_aspects = {a.keyword: a for a in aspects}
+        assert kw_aspects["좋"].sentiment_score == pytest.approx(0.20, abs=1e-4)
 
 
 # ─────────────────────────────────────────────
@@ -301,37 +335,31 @@ class TestProcess:
         assert result is True
         session.add_all.assert_not_called()
 
-    def test_skip_if_no_preprocessed_record(self):
+    def test_fails_if_no_preprocessed_record(self):
         session = _make_session(already_analyzed=False)
         session.get.return_value = None
         result = self.analyzer.process(session, self.review_id)
-        assert result is True
+        assert result is False
         session.add_all.assert_not_called()
-        # No RMI status update when preprocessed record is absent (not a terminal state)
         assert session.get.call_count == 1
 
-    def test_skip_if_empty_refined_text(self):
+    def test_fails_if_empty_refined_text(self):
         session = _make_session(already_analyzed=False)
         preprocessed = MagicMock()
         preprocessed.refined_text = ""
-        rmi_mock = MagicMock()
-        # First get(ReviewPreprocessed) → preprocessed, second get(ReviewMasterIndex) → rmi_mock
-        session.get.side_effect = [preprocessed, rmi_mock]
+        session.get.return_value = preprocessed
         result = self.analyzer.process(session, self.review_id)
-        assert result is True
+        assert result is False
         session.add_all.assert_not_called()
-        assert rmi_mock.processing_status == ProcessingStatusType.ANALYZED
 
-    def test_skip_if_no_keywords_found(self):
+    def test_fails_if_no_keywords_found(self):
         session = _make_session(already_analyzed=False)
         preprocessed = MagicMock()
         preprocessed.refined_text = "안녕하세요 반갑습니다"  # no matching keywords
         session.get.return_value = preprocessed
         result = self.analyzer.process(session, self.review_id)
-        assert result is True
-        # add_all([]) may be called — verify no aspects were inserted
-        for call in session.add_all.call_args_list:
-            assert call[0][0] == []
+        assert result is False
+        session.add_all.assert_not_called()
 
     def test_happy_path_adds_aspects(self):
         session = _make_session(already_analyzed=False)

--- a/tests/test_gold_action_analyzer.py
+++ b/tests/test_gold_action_analyzer.py
@@ -3,7 +3,7 @@
 Coverage:
 - _calc_attention(): Case A / Case B / no mismatch
 - _apply_lfs(): 각 LF 독립 동작, 다중 LF, zero votes
-- _build_record(): 정상 경로, 데이터 없음 skip
+- _build_record(): 정상 경로, 데이터 없음 failure
 - process(): 이미 분석됨 skip, 정상 적재, LLM 실패 시에도 저장
 - _generate_summary(): LLM 성공, 실패(max retry), client=None
 """
@@ -237,13 +237,13 @@ class TestProcess:
         assert result is True
         session.merge.assert_not_called()
 
-    def test_skip_if_no_rmi(self):
+    def test_fails_if_no_rmi(self):
         session = _make_session(already_analyzed=False)
         # session.get returns None for any model (no ReviewMasterIndex found)
         session.get.side_effect = None
         session.get.return_value = None
         result = self.analyzer.process(session, self.review_id)
-        assert result is True
+        assert result is False
         session.merge.assert_not_called()
 
     def test_happy_path_merges_record(self):


### PR DESCRIPTION
## Summary

Closes #84.

This PR fixes the Gold ABSA orphan path found during local E2E data-load verification. Short live reviews could reach `ANALYZED` without a corresponding `review_aspects` row, causing `post_aggregate_validate` to fail `orphan_integrity` with `missing_aspects=17`.

## Root cause

- Okt sometimes returns no usable nouns for short live reviews such as `굿`, `좋아요`, `편하게`, and `감사합니다`.
- `GoldABSAAnalyzer` did not fall back to dictionary matching when Okt returned an empty usable result.
- ABSA treated zero generated aspects as success, so the orchestrator could mark reviews as `ANALYZED` while upstream `review_aspects` rows were missing.
- `GoldActionAnalyzer` also treated missing required upstream data as a successful skip.

## Changes

- Add dictionary fallback when Okt returns no usable keywords.
- Extend the sentiment/category dictionary for observed short-review stems: `굿`, `편하`, `감사`.
- Return failure when ABSA cannot produce required aspect rows, preventing invalid `ANALYZED` state transitions.
- Return failure when action analysis lacks required upstream data.
- Add regression coverage for short feedback, compact negation (`안좋음`), false-positive guards, and failure contracts.

## Validation

```text
PYTHONPATH=. uv run pytest tests/test_gold_absa_analyzer.py tests/test_gold_action_analyzer.py tests/test_gold_orchestrator.py tests/test_post_aggregate_validation.py -q
98 passed, 1 warning in 1.32s
```

Local Gold follow-up evidence from the E2E run:

```text
Gold Orchestrator 완료: total=17, analyzed=17, failed=0
Gold Aggregator 완료: date=2026-05-04
Step post_aggregate_validate -> success
orphan_integrity: missing_action_analysis=0, missing_app_review=0, missing_preprocessed=0, missing_aspects=0
mart_count_consistency: expected_analyzed_review_count=58, fact_service_review_daily_total=58
```

The remaining `fresh_ingestion` warning is expected for the follow-up because Gold/aggregate targeted `review_created_at=2026-05-04`, while ingestion occurred on `2026-05-05`.

## Risk

Narrow Gold-layer behavior change. The key contract is stricter: required upstream analysis gaps now fail instead of silently producing orphaned `ANALYZED` rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Extended sentiment vocabulary to recognize additional Korean expressions
  * Improved negation detection to handle compact negation patterns without spaces for more precise sentiment analysis

* **Bug Fixes**
  * Strengthened validation for incomplete or missing review data
  * Enhanced error handling for more reliable processing feedback
  * More accurate sentiment scoring across varying text structures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->