### PR TITLE
docs: 저장소 전체에 계층형 AGENTS.md 추가 (28개)

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,42 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# .github
+
+## Purpose
+GitHub platform configuration. Currently holds only the CI workflow definitions that validate the
+database bootstrap and migration path on every pull request and on pushes to `main`.
+
+## Key Files
+None at this level.
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `workflows/` | GitHub Actions workflow definitions (see `workflows/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- There is no issue/PR template, CODEOWNERS, or Dependabot config here yet; adding one is a
+  deliberate change, not a side effect.
+- Workflow content is asserted by `tests/test_ci_workflows.py`, so CI changes need a matching test
+  update.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run pytest tests/test_ci_workflows.py -q
+```
+
+### Common Patterns
+Third-party actions are pinned to full commit SHAs rather than tags.
+
+## Dependencies
+
+### Internal
+`tests/test_ci_workflows.py`, `scripts/bootstrap_db.py`, `alembic/`.
+
+### External
+GitHub Actions runners and the `pgvector/pgvector:pg17` service image.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,52 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# .github/workflows
+
+## Purpose
+GitHub Actions definitions. The single workflow proves that a database can be built two ways — from
+an empty schema through Alembic, and through the local bootstrap script — and that both end at the
+same Alembic head.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `bootstrap-db.yml` | Job `bootstrap-db` on `pull_request`, `push: main`, and `workflow_dispatch`. Runs a `pgvector/pgvector:pg17` service (SHA-pinned) on 5432, Python 3.12 + `uv sync --frozen`, then: single-head check → drop/recreate `public` + `alembic upgrade head` → `alembic current --check-heads` → `scripts/bootstrap_db.py` → head check again → focused pytest subset |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- `permissions: contents: read` and SHA-pinned third-party actions are deliberate supply-chain
+  choices; keep both when editing or adding a workflow.
+- The single-head assertion is shell-based (`alembic heads | wc -l` must equal 1). Adding a
+  migration branch will fail CI here first.
+- Both `DATABASE_URL` and `TEST_DATABASE_URL` point at the same CI service database, and the
+  workflow drops the `public` schema — never point these at anything shared.
+- CI runs only the bootstrap-focused tests (`test_ci_workflows.py`, `test_bootstrap_db.py`,
+  `test_local_dev_setup.py`, `test_alembic_config.py`). The Gold/mart suites are not covered here;
+  run them locally against the Docker test stack.
+- `tests/test_ci_workflows.py` asserts the contents of this file — update the test in the same
+  change.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run pytest tests/test_ci_workflows.py -q
+```
+
+### Common Patterns
+`"on":` is quoted to avoid the YAML boolean pitfall; every step is named; heredoc Python
+(`uv run python - <<'PY'`) is used for inline DB setup instead of an extra script file.
+
+## Dependencies
+
+### Internal
+`scripts/bootstrap_db.py`, `alembic/`, `pyproject.toml` + `uv.lock`, the four focused test modules.
+
+### External
+`actions/checkout`, `actions/setup-python`, `astral-sh/setup-uv`, the `pgvector/pgvector:pg17`
+service image.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/.gitignore
+++ b/.gitignore
@@ -215,6 +215,7 @@ $RECYCLE.BIN/
 # Markdown files
 *.md
 !README.md
+!AGENTS.md
 
 # SQL
 *.sql

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,91 @@
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# reai-data
+
+## Purpose
+Korean financial-app review ETL and NLP analytics pipeline. It crawls App Store / Play Store
+reviews for 63 banking apps, lands them as Bronze Parquet in MinIO/S3, cleanses them to Silver,
+enriches them in the Gold layer (embeddings → ABSA → actionability/LLM summary), and aggregates
+into PostgreSQL fact tables plus a denormalized serving mart consumed by a dashboard backend.
+The medallion flow is orchestrated either by the Airflow DAG in `dags/` or by the step CLI
+(`src/pipeline/cli.py`, `scripts/run_pipeline.py`). Storage is hybrid: bulk review text lives in
+Parquet, while state, index, and analytics tables live in PostgreSQL (pgvector).
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `pyproject.toml` | Project metadata and dependencies; requires Python >= 3.12, dev group is `pytest` |
+| `uv.lock` | Locked dependency graph; install with `uv sync` (CI uses `uv sync --frozen`) |
+| `.python-version` | Pins the interpreter to 3.12 |
+| `alembic.ini` | Alembic config (`script_location = alembic`, `prepend_sys_path = .`, UTC) |
+| `docker-compose.yml` | Local infra: PostgreSQL `pgvector/pgvector:pg17` on 5432, MinIO on 9000/9001, bucket bootstrap |
+| `docker-compose.test.yml` | Test infra: `test-postgres` on `${TEST_POSTGRES_PORT:-5433}`/testdb, `test-minio` on 9002/9003 |
+| `.env.example` | Full environment template (DATABASE_URL, MINIO_*, OPENAI_API_KEY, ENABLE_PARQUET_WRITE) |
+| `.env.local.example` | Minimal local-stack env matching `docker-compose.yml` |
+| `reai.vuerd.json` | ERD source (vuerd format) for the physical schema |
+| `.gitignore` | Ignores `.env`, `data/`, `logs/` among others |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `src/` | All application code: crawlers, processing, gold analytics, loaders, models, pipeline (see `src/AGENTS.md`) |
+| `scripts/` | Thin CLI entrypoints invoked by Airflow and by humans (see `scripts/AGENTS.md`) |
+| `dags/` | Airflow DAG definition for the daily ETL run (see `dags/AGENTS.md`) |
+| `tests/` | pytest suite; requires a real PostgreSQL database (see `tests/AGENTS.md`) |
+| `sql/` | Immutable schema snapshots and seed reference data (see `sql/AGENTS.md`) |
+| `alembic/` | Versioned schema migrations on top of the schema v4 baseline (see `alembic/AGENTS.md`) |
+| `config/` | YAML runtime config, app-id lists, and NLP dictionaries (see `config/AGENTS.md`) |
+| `docs/` | Contracts, runbooks, policies, and plan/spec history (see `docs/AGENTS.md`) |
+| `.github/` | GitHub Actions CI (see `.github/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- Run everything from the repo root with `PYTHONPATH=.` and `uv run` — `src.*` imports assume the
+  root is on `sys.path` (`scripts/*.py` insert it themselves, the Airflow DAG exports it).
+- `sql/schema_v4.sql` is the **immutable** Alembic baseline. Schema changes go into a new Alembic
+  revision under `alembic/versions/`, never into the baseline file. See `docs/schema-management.md`.
+- `pyproject.toml` declares `readme = "README.md"`, but no `README.md` exists at the root; packaging
+  commands that resolve the readme will fail until one is added.
+- Never read or write `.env`; use `.env.example` / `.env.local.example` as the source of truth for
+  which variables exist.
+- Gold analyze/aggregate steps require a live `OPENAI_API_KEY`; crawl/load/cleanse do not.
+
+### Testing Requirements
+The suite tests against real PostgreSQL — SQLite substitutes and mocked databases are not accepted
+(see `tests/conftest.py`). Standard flow:
+
+```bash
+docker compose -f docker-compose.test.yml up -d test-postgres
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest
+```
+
+Markers registered in `tests/conftest.py:619`: `slow`, `integration`, `requires_db`.
+CI (`.github/workflows/bootstrap-db.yml`) runs only the bootstrap-focused subset:
+`tests/test_ci_workflows.py tests/test_bootstrap_db.py tests/test_local_dev_setup.py tests/test_alembic_config.py`.
+
+### Common Patterns
+- Every component takes `config_path: str = "config/crawler_config.yml"` and builds its own
+  `DatabaseConnector`; pass a config path explicitly in tests.
+- Logging is always `from src.utils.logger import get_logger; logger = get_logger(__name__)`.
+- Review identity uses UUID v7 (`uuid6.uuid7`) so IDs sort by creation time.
+- Pipeline steps return the `RunResult` dataclass (`src/pipeline/steps.py:19`); failures are values,
+  not exceptions, and `run_steps` stops at the first non-success step.
+- Review lifecycle is tracked by `review_master_index.processing_status`:
+  `RAW → CLEANED → ANALYZED`, with `FAILED` + `retry_count < 3` eligible for retry.
+
+## Dependencies
+
+### Internal
+Root config and compose files are consumed by `src/`, `scripts/`, `dags/`, and `tests/`; the layer
+boundary is documented in `docs/backend-datamart-contract.md`.
+
+### External
+`sqlalchemy` + `psycopg2-binary` + `pgvector` (PostgreSQL), `alembic` (migrations), `boto3`
+(MinIO/S3), `pyarrow` + `pandas` (Parquet), `pydantic` (schema validation), `openai` +
+`sentence-transformers` + `transformers` + `torch` (embeddings/LLM), `snorkel` (weak supervision),
+`konlpy` + `nltk` + `flashtext` + `emoji` (Korean text processing),
+`google-play-scraper` + `requests` (crawling), `uuid6`, `pyyaml`, `python-dotenv`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/alembic/AGENTS.md
+++ b/alembic/AGENTS.md
@@ -1,0 +1,59 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# alembic
+
+## Purpose
+Versioned schema migration environment. Alembic sits on top of the frozen `sql/schema_v4.sql`
+baseline: existing databases are stamped at revision `20260430_0001`, empty databases can be built
+by `alembic upgrade head`, and every later schema change is a hand-written revision.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `env.py` | Migration runner. Loads `.env`, resolves the DB URL, keeps `target_metadata = None` (autogenerate deliberately disabled), configures `compare_type` / `compare_server_default`, and runs offline or online with `NullPool` |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `versions/` | Revision scripts, starting from the schema v4 baseline (see `versions/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- Database URL resolution order in `env.py:24` is: `-x database_url=…` → `config.attributes["database_url"]`
+  (programmatic, used by `src/bootstrap_db.py`) → `DATABASE_URL` env var → `sqlalchemy.url` in
+  `alembic.ini`. It raises if none is set — `alembic.ini` deliberately ships no URL.
+- `target_metadata` is `None` on purpose: the ORM models in `src/models/` are not yet a lossless
+  representation of the baseline, so `alembic revision --autogenerate` and `alembic check` are not
+  part of the workflow. Do not wire metadata in without the model/schema alignment work.
+- Write migrations by hand and review PostgreSQL-specific details manually: enum changes, pgvector
+  indexes, partial indexes, partitioned tables, and backfills.
+- Keep a single head. `.github/workflows/bootstrap-db.yml` fails the build when `alembic heads`
+  prints more than one line.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run alembic heads                 # must print exactly one head
+PYTHONPATH=. uv run alembic upgrade head          # against a local PostgreSQL
+PYTHONPATH=. uv run python scripts/bootstrap_db.py
+PYTHONPATH=. uv run alembic current --check-heads
+PYTHONPATH=. uv run pytest tests/test_alembic_config.py tests/test_bootstrap_db.py tests/test_ci_workflows.py -q
+```
+The full checklist lives in `docs/schema-management.md`.
+
+### Common Patterns
+Revision files declare `revision` / `down_revision` explicitly with date-ordered IDs
+(`YYYYMMDD_NNNN`), and use `op.get_bind()` for raw SQL execution when a statement cannot be
+expressed through Alembic operations.
+
+## Dependencies
+
+### Internal
+`alembic.ini`, `sql/schema_v4.sql` (baseline source), `src/bootstrap_db.py` (programmatic driver),
+`docs/schema-management.md` (policy).
+
+### External
+`alembic`, `sqlalchemy`, `python-dotenv`, `psycopg2-binary`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/alembic/versions/AGENTS.md
+++ b/alembic/versions/AGENTS.md
@@ -1,0 +1,56 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# alembic/versions
+
+## Purpose
+Migration revision scripts. Currently holds only the schema v4 baseline, which replays the frozen
+`sql/schema_v4.sql` snapshot so an empty database can be built entirely through Alembic while
+existing databases are stamped at the same revision instead of re-running the DDL.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `20260430_0001_schema_v4_baseline.py` | Revision `20260430_0001`, `down_revision = None`. `upgrade()` executes the sibling `.sql` file through the raw DBAPI cursor; `downgrade()` intentionally raises |
+| `20260430_0001_schema_v4_baseline.sql` | The immutable DDL snapshot matching `sql/schema_v4.sql` at the time Alembic was introduced |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- The baseline pair is frozen. Do not edit either file — a change would desynchronize databases
+  already stamped at `20260430_0001`.
+- Downgrade past the baseline is unsupported by design; the documented recovery for local databases
+  is `PYTHONPATH=. uv run python scripts/bootstrap_db.py`.
+- New revisions must set `down_revision` to the current head and keep the single-head invariant that
+  CI enforces. Use the `YYYYMMDD_NNNN` id convention.
+- `upgrade()` here uses `op.get_bind().connection` with a raw cursor because the baseline SQL
+  contains multiple statements including PostgreSQL-specific DDL. Prefer normal `op.*` operations
+  for ordinary revisions.
+- Autogenerate is disabled (`target_metadata = None` in `alembic/env.py`) — write revisions by hand
+  and review enum changes, pgvector indexes, partial indexes, partitions, and backfills yourself.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run alembic heads                 # exactly one head
+PYTHONPATH=. uv run alembic upgrade head
+PYTHONPATH=. uv run alembic current --check-heads
+PYTHONPATH=. uv run pytest tests/test_alembic_config.py -q
+```
+
+### Common Patterns
+Module-level `revision` / `down_revision` / `branch_labels` / `depends_on` constants, a docstring
+header with revision id and create date, and SQL loaded from a sibling file via
+`Path(__file__).with_name(...)` when the DDL is too large to inline.
+
+## Dependencies
+
+### Internal
+`alembic/env.py`, `sql/schema_v4.sql`, `src/bootstrap_db.py` (`ALEMBIC_BASELINE_REVISION`).
+
+### External
+`alembic`, `psycopg2-binary`, PostgreSQL 17 with the `vector` (pgvector) extension.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -1,0 +1,63 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# config
+
+## Purpose
+File-based runtime configuration: crawler tuning, logging setup, medallion storage paths, target
+app-id lists, and Korean NLP dictionaries. Secrets never live here — they come from `.env` /
+environment variables, and `paths.yml` only references them via `${VARIABLE}` placeholders.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `crawler_config.yml` | Default config for every component (`config_path` default). Global delay/retry/timeout, per-store country/language/page counts, output settings, and app-id file locations |
+| `paths.yml` | Medallion storage layout (`bronze_dir`, `silver_dir`, `gold_dir`, `embeddings_dir`, `logs_dir`) built from `${PARQUET_BASE_PATH}`; consumed by `src/utils/path_resolver.py` |
+| `logging_config.yml` | Logging dictConfig actually loaded by `src/utils/logger.py:30`: console + rotating `logs/crawler/info.log` and `logs/error/error.log` (10 MB × 5) |
+| `logging.yml` | Near-identical logging config that no code references; `logging_config.yml` is the live one |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `app_ids/` | Store-specific app-id lists and the exclusion list (see `app_ids/AGENTS.md`) |
+| `dictionaries/` | Synonym, profanity, and stopword resources for cleansing (see `dictionaries/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- `crawler_config.yml` is the default `config_path` for crawlers, loaders, gold analyzers, and the
+  CLI (`--config`). Removing a key can break several components at once — check
+  `self.config.get(...)` call sites in `src/crawlers/` before pruning.
+- Review-volume knobs are currently set for testing (`appstore.max_reviews_per_app: 10`,
+  `playstore.reviews_per_app: 10`); raise them deliberately, not incidentally.
+- `output.*` in `crawler_config.yml` describes the legacy CSV dump path; the production Bronze path
+  is MinIO Parquet driven by `paths.yml` + `PARQUET_BASE_PATH`.
+- Do not hardcode absolute paths. Add new storage locations to `paths.yml` using `${VARIABLE}` and
+  resolve them through `PathResolver` / `get_medallion_paths()`.
+- If you touch logging, edit `logging_config.yml`; `logging.yml` is a stale duplicate and changing
+  it alone has no effect.
+
+### Testing Requirements
+`tests/test_path_resolver.py` covers placeholder substitution and medallion path building;
+`tests/test_cleanse.py` builds its own temporary dictionaries rather than reading these files, so
+dictionary edits need a manual cleansing run to verify.
+
+```bash
+PYTHONPATH=. uv run pytest tests/test_path_resolver.py -q
+```
+
+### Common Patterns
+YAML is loaded with `yaml.safe_load` and accessed defensively via
+`config.get('section', {}).get('key', <default>)`, so a missing key degrades to a coded default
+instead of raising.
+
+## Dependencies
+
+### Internal
+`src/utils/path_resolver.py`, `src/utils/logger.py`, `src/crawlers/*`, `src/pipeline/cli.py`,
+`scripts/cleanse_reviews.py`.
+
+### External
+`pyyaml`; `PARQUET_BASE_PATH` and the other variables documented in `.env.example`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/config/app_ids/AGENTS.md
+++ b/config/app_ids/AGENTS.md
@@ -1,0 +1,56 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# config/app_ids
+
+## Purpose
+Crawl targets. Plain-text lists of the store app identifiers to crawl, grouped by Korean bank
+category, plus an exclusion list. These files define the pipeline's scope: 63 apps across two
+stores, matching the seed catalog in `sql/apps_data.sql`.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `appstore_app_ids.txt` | Numeric App Store IDs, one per line, sectioned by bank type (`### 특수 은행 ###` etc.). Referenced by `crawler_config.yml → app_ids.appstore` |
+| `playstore_app_ids.txt` | Play Store package names, one per line, same sectioning. Referenced by `app_ids.playstore` |
+| `excluded_apps.txt` | Exclusion list in `platform:app_id  # reason` form. Currently all lines are comments, so nothing is excluded |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- `BaseCrawler.read_app_ids()` skips blank lines and lines starting with `#`, so section headers and
+  documentation comments are safe.
+- Adding an app here is only half the change: crawled reviews resolve against `apps` /
+  `app_metadata`, so a new app also needs seed rows in `sql/apps_data.sql` and
+  `sql/app_metadata_data.sql` (and the bootstrap verification counts of 39 / 63 / 63 will need
+  updating in `src/bootstrap_db.py`).
+- App Store entries are numeric IDs; Play Store entries are package names. Mixing them silently
+  yields empty crawls.
+- File locations are configurable via `config/crawler_config.yml`; do not hardcode these paths in
+  new code — read them from config as `appstore_crawler.py:37` / `playstore_crawler.py:36` do.
+
+### Testing Requirements
+No test reads these files directly — `tests/conftest.py` provides a `sample_app_id_file` fixture
+instead. Verify changes with a scoped live crawl:
+
+```bash
+PYTHONPATH=. uv run python scripts/crawl_reviews.py
+```
+
+### Common Patterns
+`#`-prefixed comments carry section names and exclusion reasons; entries stay grouped by bank
+category so the list stays reviewable by humans.
+
+## Dependencies
+
+### Internal
+`config/crawler_config.yml`, `src/crawlers/base_crawler.py`, `src/crawlers/appstore_crawler.py`,
+`src/crawlers/playstore_crawler.py`, `sql/apps_data.sql`.
+
+### External
+App Store and Google Play identifier namespaces.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/config/dictionaries/AGENTS.md
+++ b/config/dictionaries/AGENTS.md
@@ -1,0 +1,57 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# config/dictionaries
+
+## Purpose
+Korean-language reference data for the Bronze → Silver cleansing stage. These files encode
+domain knowledge (bank/app brand variants, abusive language, low-signal tokens) that no general NLP
+model provides, so cleansing output quality is directly tied to their contents.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `synonyms.json` | Flat JSON map of surface form → canonical form, mostly banking-app brand variants (`"신한 슈퍼 SOL": "신한슈퍼솔"`). Wired in as `SYNONYMS_PATH` by `scripts/cleanse_reviews.py:30` |
+| `profanity.json` | Flat JSON map of term → tag; tags are `[PROFANITY]`, `[STRONG_NEG]`, `[THREAT]`. Wired in as `PROFANITY_PATH` by `scripts/cleanse_reviews.py:31` |
+| `stopwords.txt` | 51 low-signal Korean tokens, one per line (`앱`, `어플`, `하다`, …). Currently not read by any code path |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Both JSON files are flat `{string: string}` maps — no nesting, no arrays. The loader assumes that
+  shape.
+- Keep them UTF-8 without a BOM; the review corpus is Korean and encoding damage is silent.
+- Profanity tags are consumed downstream as sentiment signals; inventing a new tag string means
+  updating the consuming rules in `src/processing/cleanse.py` and `src/gold/`.
+- Synonym canonicalization affects ABSA keyword grouping and therefore `fact_service_aspect_daily`
+  rows. A mapping change is an analytics change, not just a text change.
+- `stopwords.txt` is referenced only in prose (`src/schemas/parquet/review_preprocessed.py:24`
+  describes stopword removal). Confirm the actual consumer before assuming it is live.
+- The DB also has `synonyms` / `profanity` / `financial_terms` tables (`src/models/dictionary.py`).
+  These files are the file-based path used by the cleansing CLI; keep the two in mind when
+  changing either.
+
+### Testing Requirements
+`tests/test_cleanse.py` writes its own temporary dictionaries, so edits here are not covered
+automatically. Verify with a real cleansing run over a known Bronze partition:
+
+```bash
+PYTHONPATH=. uv run python scripts/cleanse_reviews.py --date YYYY-MM-DD
+```
+
+### Common Patterns
+Longest-match-first replacement is expected — order variants so the most specific surface form is
+present (`"신한 슈퍼 SOL"` alongside `"슈퍼솔"`).
+
+## Dependencies
+
+### Internal
+`scripts/cleanse_reviews.py`, `src/processing/cleanse.py`, `src/models/dictionary.py`.
+
+### External
+None (data files only).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/dags/AGENTS.md
+++ b/dags/AGENTS.md
@@ -1,0 +1,59 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# dags
+
+## Purpose
+Airflow DAG definitions. Holds the single daily production DAG that chains the six pipeline stages
+by shelling out to the repository's own scripts and step functions, so the DAG contains scheduling
+and timeout policy only — never analytics logic.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `financial_review_pipeline.py` | DAG `financial_review_etl_pipeline`: `@daily`, `catchup=False`, 3 retries / 5 min, tags `finance, etl, reviews, nlp` |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Task chain and timeouts: `crawl_reviews` (2h) → `load_reviews` (30m) → `cleanse_reviews` (1h) →
+  `gold_analyze` (3h) → `gold_aggregate` (1h) → `post_aggregate_validate` (15m).
+- All tasks are `BashOperator`s built from `PROJECT_ROOT` and `PYTHON_BIN` environment variables
+  (defaults: the DAG file's parent-of-parent, and `${PROJECT_ROOT}/.venv/bin/python`). Keep paths
+  derived from those variables — no absolute paths.
+- `gold_analyze` and `gold_aggregate` inline `python -c` calls into `src.pipeline.steps` and map
+  `RunResult.status` to the exit code; `post_aggregate_validate` uses
+  `python -m src.pipeline.cli --steps post_aggregate_validate --target-date {{ ds }}`.
+- `gold_aggregate` intentionally aggregates a **single** logical date (`target_date='{{ ds }}'`).
+  Range backfill (`run_aggregate(start_date=..., end_date=...)`) is a manual repair tool only —
+  see `docs/superpowers/specs/2026-04-18-aggregate-range-backfill-design.md`.
+- DAG success requires the DB validation task, not just task exit codes; the contract is in
+  `docs/airflow-continuous-load-readiness.md`.
+- The file carries `# pyright: reportMissingImports=false` because `airflow` is not a project
+  dependency in `pyproject.toml`; it resolves only in the Airflow environment.
+
+### Testing Requirements
+`tests/test_airflow_dag_validation_wiring.py` and `tests/test_airflow_readiness_docs.py` parse this
+file as text and assert the wiring/documentation contract — they do not import Airflow. Run:
+
+```bash
+PYTHONPATH=. uv run pytest tests/test_airflow_dag_validation_wiring.py tests/test_airflow_readiness_docs.py -q
+```
+
+### Common Patterns
+Jinja `{{ ds }}` supplies the logical date to every date-scoped task; each bash command starts with
+`cd {PROJECT_ROOT} && PYTHONPATH=.`.
+
+## Dependencies
+
+### Internal
+`scripts/crawl_reviews.py`, `scripts/load_reviews.py`, `scripts/cleanse_reviews.py`,
+`src.pipeline.steps`, `src.pipeline.cli`.
+
+### External
+`apache-airflow` (provided by the Airflow deployment, not by `pyproject.toml`).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,60 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# docs
+
+## Purpose
+Human- and agent-facing documentation for contracts, runbooks, and policy. These files are not
+decorative: several are asserted by tests (`tests/test_airflow_readiness_docs.py`,
+`tests/test_backend_datamart_serving_readiness.py`), so they are part of the delivery contract.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `backend-datamart-contract.md` | Physical table contract for the four backend-facing Gold tables; the authoritative interface for dashboard consumers |
+| `airflow-continuous-load-readiness.md` | Defines DAG success as task success **plus** the `post_aggregate_validate` DB check, and the severity policy behind it |
+| `backend-datamart-serving-readiness.md` | Runbook for the manual release proof of mart serving readiness |
+| `local-development.md` | Local stack setup: docker compose, `.env.local.example`, bootstrap, minimum ETL flow, verification queries |
+| `schema-management.md` | Alembic baseline strategy, migration workflow, reference-data ownership, pre-merge checklist |
+| `pipeline-failure-policy.md` | Where failures are recorded per stage in schema v4 (batch DLQ vs review-level FAILED) |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `evidence/` | Release evidence artifacts for readiness claims (see `evidence/AGENTS.md`) |
+| `superpowers/` | Implementation plans and design specs from agent-driven work (see `superpowers/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- `airflow-continuous-load-readiness.md` and the serving-readiness docs are parsed by tests; edit
+  their headings and stated guarantees only alongside the corresponding code and test change.
+- When behavior changes, update the owning doc in the same change: schema → `schema-management.md`,
+  DAG contract → `airflow-continuous-load-readiness.md`, mart columns →
+  `backend-datamart-contract.md`, failure handling → `pipeline-failure-policy.md`.
+- Docs here are written in English; commands are always shown rooted at the repo with
+  `PYTHONPATH=. uv run …`.
+- Evidence documents record real runs. Do not fabricate or pre-fill row counts, timestamps, or
+  crawl results.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run pytest tests/test_airflow_readiness_docs.py -q
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_backend_datamart_serving_readiness.py -q
+```
+
+### Common Patterns
+Each doc opens with an H1 title, then a "Contract boundary" or "Purpose"-style section that states
+scope before details. Commands are fenced bash blocks; SQL evidence shapes are fenced sql blocks.
+
+## Dependencies
+
+### Internal
+Describes `src/pipeline/post_aggregate_validation.py`, `src/gold/aggregator.py`,
+`src/bootstrap_db.py`, `alembic/`, `dags/financial_review_pipeline.py`, and the compose files.
+
+### External
+None (Markdown only).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/docs/evidence/AGENTS.md
+++ b/docs/evidence/AGENTS.md
@@ -1,0 +1,44 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# docs/evidence
+
+## Purpose
+Release evidence artifacts. Holds the recorded proof for readiness claims that automated PR checks
+cannot make on their own, because they depend on live store responses, real credentials, or
+production-like data.
+
+## Key Files
+None at this level — evidence lives in per-claim subdirectories.
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `backend-datamart-serving-readiness/` | Evidence path for backend datamart serving readiness (see `backend-datamart-serving-readiness/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- Evidence is a record of what actually ran. Never generate, estimate, or pre-fill counts,
+  timestamps, or command output here.
+- One subdirectory per readiness claim, each with a `README.md` explaining what the automated checks
+  cover and what must be proven manually.
+- The runbook that defines what to record is `docs/backend-datamart-serving-readiness.md`.
+
+### Testing Requirements
+`tests/test_backend_datamart_serving_readiness.py` checks the readiness contract; the evidence files
+themselves are reviewed by humans at release time.
+
+### Common Patterns
+Each evidence README states the boundary between automated proof and manual proof before listing
+what must be captured.
+
+## Dependencies
+
+### Internal
+`docs/backend-datamart-serving-readiness.md`, `docker-compose.test.yml`, `src/gold/aggregator.py`.
+
+### External
+None (Markdown only).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/docs/evidence/backend-datamart-serving-readiness/AGENTS.md
+++ b/docs/evidence/backend-datamart-serving-readiness/AGENTS.md
@@ -1,0 +1,55 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# docs/evidence/backend-datamart-serving-readiness
+
+## Purpose
+Release evidence path for the claim that the backend-facing data marts are ready to serve. Automated
+PR checks cover the local Docker PostgreSQL aggregate path with a deterministic fixture; live object
+storage proof and live crawl results are recorded here by hand because they depend on external store
+responses and credentials that are out of scope for CI.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `README.md` | States the automated-vs-manual proof boundary and what a release must record here |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Record only what actually ran: command, target service, timestamp, `target_date`, row counts for
+  all four mart tables, and any failures or caveats. Never synthesize numbers.
+- The four tables in scope are `fact_service_review_daily`, `fact_service_aspect_daily`,
+  `fact_category_radar_scores`, and `srv_daily_review_list`.
+- The capture procedure and the SQL shape for row counts are in
+  `docs/local-development.md` ("Manual live crawl smoke evidence") and
+  `docs/backend-datamart-serving-readiness.md`.
+
+### Testing Requirements
+The PR-safe portion of the proof:
+
+```bash
+docker compose -f docker-compose.test.yml up -d test-postgres
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_backend_datamart_contract.py tests/test_backend_datamart_serving_readiness.py -q
+```
+The manual portion uses the real entrypoint:
+`PYTHONPATH=. uv run python scripts/run_pipeline.py --steps gold,aggregate --target-date YYYY-MM-DD`.
+
+### Common Patterns
+Evidence entries are dated and paired with the exact command that produced them, so a reviewer can
+re-run the same thing.
+
+## Dependencies
+
+### Internal
+`docs/backend-datamart-serving-readiness.md`, `docs/backend-datamart-contract.md`,
+`src/gold/aggregator.py`, `src/pipeline/post_aggregate_validation.py`, `docker-compose.test.yml`.
+
+### External
+Live App Store / Play Store responses and a real `OPENAI_API_KEY` for the manual portion.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/docs/superpowers/AGENTS.md
+++ b/docs/superpowers/AGENTS.md
@@ -1,0 +1,48 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# docs/superpowers
+
+## Purpose
+Agent-authored planning artifacts. Holds the design specs and task-by-task implementation plans
+produced before a change was made, kept as a record of intent and trade-offs behind features that
+are already merged.
+
+## Key Files
+None at this level.
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `plans/` | Date-stamped implementation plans with checkbox task lists (see `plans/AGENTS.md`) |
+| `specs/` | Date-stamped design specs stating goal and approach (see `specs/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- These are historical records of completed work, not a live backlog. Do not "finish" unchecked
+  boxes in an old plan without confirming the work is still wanted.
+- Naming convention is `YYYY-MM-DD-<slug>.md`, with a spec and a plan sharing the slug when both
+  exist.
+- Design decisions recorded here are still binding where code implements them — for example, the
+  aggregate design fixes `gold_aggregate` to a single logical date with range backfill as a manual
+  tool only.
+
+### Testing Requirements
+None directly. Verify against the code the document describes and the corresponding tests
+(`tests/test_gold_aggregator.py`, `tests/test_local_dev_setup.py`).
+
+### Common Patterns
+Plans open with an agentic-worker sub-skill note, a **Goal**, and checkbox (`- [ ]`) steps; specs
+open with a **Goal** and a **Design** bullet list.
+
+## Dependencies
+
+### Internal
+`src/gold/aggregator.py`, `dags/financial_review_pipeline.py`, `docker-compose.yml`,
+`docs/local-development.md`.
+
+### External
+None (Markdown only).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/docs/superpowers/plans/AGENTS.md
+++ b/docs/superpowers/plans/AGENTS.md
@@ -1,0 +1,46 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# docs/superpowers/plans
+
+## Purpose
+Task-by-task implementation plans written before a change was executed. Each plan states a goal and
+breaks it into checkbox steps an agent or engineer can work through in order.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `2026-04-18-aggregate-range-backfill.md` | Plan to restore single-date scheduled aggregation and add an explicit date-range backfill utility for manual repair. Implemented as `GoldAggregator.run_range()` |
+| `2026-04-18-local-dev-compose.md` | Plan to add the local PostgreSQL + MinIO compose stack, env template, and usage docs. Implemented as `docker-compose.yml`, `.env.local.example`, `docs/local-development.md` |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Both plans correspond to work that is already merged. Unchecked boxes are historical state, not a
+  live to-do list — confirm intent before acting on one.
+- The paired design rationale for the backfill plan lives in
+  `../specs/2026-04-18-aggregate-range-backfill-design.md`.
+- New plans follow `YYYY-MM-DD-<slug>.md` and keep the slug consistent with any matching spec.
+
+### Testing Requirements
+None directly. Validate against the implementing code and its tests:
+`tests/test_gold_aggregator.py` for the backfill plan, `tests/test_local_dev_setup.py` for the
+compose plan.
+
+### Common Patterns
+Header note naming the required sub-skill, a bolded **Goal**, then ordered `- [ ]` steps small enough
+to verify individually.
+
+## Dependencies
+
+### Internal
+`src/gold/aggregator.py`, `src/pipeline/steps.py:run_aggregate`, `docker-compose.yml`,
+`docs/local-development.md`.
+
+### External
+None (Markdown only).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/docs/superpowers/specs/AGENTS.md
+++ b/docs/superpowers/specs/AGENTS.md
@@ -1,0 +1,43 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# docs/superpowers/specs
+
+## Purpose
+Design specs stating the goal and chosen approach for a change before implementation. Shorter than
+the plans in `../plans/`: a spec explains *why* the design is what it is, the plan enumerates the
+steps.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `2026-04-18-aggregate-range-backfill-design.md` | Restores `gold_aggregate` to `target_date='{{ ds }}'` so scheduled runs aggregate only the logical execution date, and keeps a bounded manual backfill utility for exceptional repair |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- This design is still binding on the code: the Airflow task must aggregate a single date, and
+  `GoldAggregator.run_range()` stays a manual repair tool. Do not make range backfill the scheduled
+  default without superseding this spec.
+- Specs are paired with a plan of the same slug in `../plans/` where one exists.
+- Naming convention: `YYYY-MM-DD-<slug>-design.md`.
+
+### Testing Requirements
+None directly. The behavior it constrains is covered by `tests/test_gold_aggregator.py` and
+`tests/test_airflow_dag_validation_wiring.py`.
+
+### Common Patterns
+A bolded **Goal** line followed by a **Design** bullet list naming the concrete code paths affected.
+
+## Dependencies
+
+### Internal
+`dags/financial_review_pipeline.py`, `src/gold/aggregator.py`, `src/pipeline/steps.py`.
+
+### External
+None (Markdown only).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,61 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# scripts
+
+## Purpose
+Thin executable entrypoints. Every script inserts the repository root into `sys.path` and then
+delegates to `src.pipeline.steps` (or `src.bootstrap_db` / `src.processing.cleanse`). They exist so
+Airflow `BashOperator` tasks, CI jobs, and humans share the same code paths as the step CLI. No
+business logic belongs here.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `run_pipeline.py` | Unified entrypoint; delegates to `src.pipeline.cli.main` (`--steps`, `--target-date`, ...) |
+| `crawl_reviews.py` | Crawl step only → Bronze Parquet in MinIO + `ingestion_batch` PENDING rows |
+| `load_reviews.py` | Load step only → pending Parquet batches into `review_master_index` (RAW) |
+| `cleanse_reviews.py` | Bronze → Silver cleansing CLI; `--date YYYY-MM-DD`, wires `config/dictionaries/{synonyms,profanity}.json` |
+| `preprocess_reviews.py` | Deprecated preprocess step; `run_preprocess` now warns and returns failure |
+| `extract_features.py` | ABSA feature extraction step only (Gold) |
+| `generate_embeddings.py` | Embedding generation step only (Gold); optional model name argument |
+| `bootstrap_db.py` | Local DB reset/seed wrapper around `src.bootstrap_db.main` |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Always invoke with the repo root as CWD: `PYTHONPATH=. uv run python scripts/<name>.py`.
+- Scripts must stay thin. New behavior goes into `src/pipeline/steps.py` or the owning module, and
+  the script only parses arguments and maps the `RunResult` status to an exit code.
+- `dags/financial_review_pipeline.py` invokes `crawl_reviews.py`, `load_reviews.py`, and
+  `cleanse_reviews.py` by path — renaming or moving a script breaks the DAG.
+- File paths in `cleanse_reviews.py` are derived from `_PROJECT_ROOT / 'config' / 'dictionaries'`;
+  keep new paths derived that way rather than hardcoded absolute strings.
+
+### Testing Requirements
+No dedicated per-script tests; coverage comes from the step layer
+(`tests/test_pipeline_steps.py`, `tests/test_cli_parsing.py`, `tests/test_cleanse.py`) and from
+`tests/test_bootstrap_db.py` / `tests/test_local_dev_setup.py` for the bootstrap path. After
+changing a script, run the corresponding step test plus a manual smoke run against the local stack.
+
+### Common Patterns
+```python
+ROOT = Path(__file__).parent.parent
+sys.path.insert(0, str(ROOT))
+from src.pipeline.steps import run_x  # noqa: E402
+```
+`main()` returns `0` on success / `1` on failure and is invoked via `raise SystemExit(main())`.
+
+## Dependencies
+
+### Internal
+`src.pipeline.steps`, `src.pipeline.cli`, `src.processing.cleanse`, `src.bootstrap_db`,
+`config/dictionaries/`.
+
+### External
+`python-dotenv` (loading `.env` in `crawl_reviews.py`), plus whatever the delegated step imports.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/sql/AGENTS.md
+++ b/sql/AGENTS.md
@@ -1,0 +1,64 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# sql
+
+## Purpose
+Raw PostgreSQL DDL snapshots and seed reference data. `schema_v4.sql` is the current — and
+immutable — Alembic baseline; the three `*_data.sql` files own the business catalog (logical
+services, physical apps, and their SCD Type 2 metadata) that local and CI databases need before the
+pipeline can run. Older schema snapshots are kept for history only.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `schema_v4.sql` | Current baseline DDL (2026-03-05): Bronze → Silver → Gold → data mart, pgvector, partitioned `srv_daily_review_list`. Applied by `src/bootstrap_db.py`, mirrored by Alembic revision `20260430_0001` |
+| `app_service_data.sql` | Seed: 39 logical service masters, UUIDs `01960000-{NNNN}-7000-8000-…`. Load order 1 |
+| `apps_data.sql` | Seed: 63 physical apps (37 App Store + 26 Play Store), UUIDs `01960001-{NNNN}-…`. Load order 2 |
+| `app_metadata_data.sql` | Seed: 63 active SCD Type 2 rows linking apps ↔ services with group/bank classification. Load order 3 |
+| `organizations_data.sql` | Organization hierarchy rows generated from `organization.csv`; not part of the bootstrap load order |
+| `schema_v3.sql` | Historical schema snapshot (2026-02-16); not referenced by code |
+| `schema_v2.sql` | Historical schema snapshot (2026-02-04); not referenced by code |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- **Do not edit `schema_v4.sql`.** It is the frozen Alembic baseline; its byte-content is mirrored
+  in `alembic/versions/20260430_0001_schema_v4_baseline.sql`. New DDL goes into a fresh Alembic
+  revision (`docs/schema-management.md`).
+- The bootstrap load order is fixed in `src/bootstrap_db.py:20` (`SQL_FILE_ORDER`) because of FK
+  parentage: `app_service` → `apps` → `app_metadata`. Adding a seed file means updating that tuple
+  and, if the row count matters, `build_verification_queries()` (expects 39 / 63 / 63).
+- Seed files must stay idempotent — `scripts/bootstrap_db.py` re-applies them after a schema reset.
+- Migrations own structural change; seed SQL owns business catalog refreshes. Data movement belongs
+  in a migration only when it is inseparable from a schema change.
+- `schema_v2.sql`, `schema_v3.sql`, and `organizations_data.sql` are currently unreferenced by any
+  code, config, or doc. Treat them as history; do not delete them as part of an unrelated change.
+
+### Testing Requirements
+`tests/test_database_schema.py` asserts the objects `schema_v4.sql` creates, and
+`tests/conftest.py` applies this file to build the test database. `tests/test_bootstrap_db.py`
+covers the seed-order and verification-count contract.
+
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_database_schema.py tests/test_bootstrap_db.py -q
+```
+
+### Common Patterns
+Every file opens with a banner comment stating purpose, date, row counts, and load order. Seed rows
+use deterministic UUID v7-shaped identifiers so fixtures and expectations stay stable.
+
+## Dependencies
+
+### Internal
+`src/bootstrap_db.py`, `alembic/versions/`, `tests/conftest.py`, `src/models/` (ORM mirror).
+
+### External
+PostgreSQL 17 with the `vector` (pgvector) extension. `ltree` is **not** used — it was removed in
+issue #32, and `organizations.org_id` is plain `TEXT` with hyphen-separated levels (`1`, `1-1`, `10-5`).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,0 +1,70 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src
+
+## Purpose
+All application code for the review ETL pipeline, split by medallion stage rather than by technical
+layer. Data flows `crawlers/` (Bronze Parquet + batch registration) → `loaders/` (Parquet → DB
+index) → `processing/` (Bronze → Silver cleansing) → `gold/` (embedding, ABSA, actionability,
+aggregation) with `pipeline/` providing the step dispatcher, CLI, and post-aggregate validation.
+`models/`, `schemas/`, and `utils/` are shared infrastructure used by every stage.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `bootstrap_db.py` | Local DB bootstrap: reset `public` schema, apply `sql/schema_v4.sql`, load seed SQL, stamp `20260430_0001`, upgrade to head, verify seed counts (39/63/63). Refuses non-local hosts |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `crawlers/` | App Store / Play Store crawling → Bronze Parquet + `ingestion_batch` PENDING (see `crawlers/AGENTS.md`) |
+| `loaders/` | Pending Parquet batches → `review_master_index` RAW rows (see `loaders/AGENTS.md`) |
+| `processing/` | Bronze → Silver text cleansing pipeline (see `processing/AGENTS.md`) |
+| `gold/` | Embedding, ABSA, action analysis, orchestration, and daily aggregation (see `gold/AGENTS.md`) |
+| `pipeline/` | Step wrappers, argparse CLI, failure queries, post-aggregate validation (see `pipeline/AGENTS.md`) |
+| `models/` | SQLAlchemy ORM models mirroring schema v4 (see `models/AGENTS.md`) |
+| `schemas/` | Pydantic schemas validating Parquet payloads (see `schemas/AGENTS.md`) |
+| `utils/` | Logger, DB connector, MinIO client, Parquet writer, path resolver (see `utils/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- `src/` has no `__init__.py`; it is imported as a namespace package with the repo root on
+  `sys.path` (`PYTHONPATH=.`). Do not add a top-level `src/__init__.py` without checking every
+  entrypoint.
+- Import style is mixed: `src/crawlers/*` uses relative imports (`..utils.logger`), most newer code
+  uses absolute (`from src.utils.logger import get_logger`). Match the file you are editing.
+- Heavy dependencies (torch, transformers, snorkel, openai) are imported lazily inside
+  `src/pipeline/steps.py` functions and `GoldOrchestrator.__init__` so unrelated steps stay
+  importable when those packages are missing. Preserve that laziness.
+- Docstrings and log messages are Korean in the crawler/gold/processing code and English in the
+  pipeline/bootstrap code. Follow the surrounding file.
+
+### Testing Requirements
+Each subpackage has matching tests under `tests/` (e.g. `src/gold/aggregator.py` ↔
+`tests/test_gold_aggregator.py`). Most require a live PostgreSQL:
+
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_gold_aggregator.py -q
+```
+
+### Common Patterns
+- Constructors accept `config_path` (default `"config/crawler_config.yml"`) and instantiate
+  `DatabaseConnector(config_path)` themselves — there is no DI container.
+- Session handling is explicit: `session = self.db_connector.get_session()` inside
+  `try/except → rollback / finally → close`.
+- Batch processors expose both `process(session, review_id) -> bool` (single record, used by the
+  orchestrator) and `process_batch(batch_size, limit)` (standalone entry).
+
+## Dependencies
+
+### Internal
+`config/` YAML for runtime settings, `sql/` + `alembic/` for the schema these models mirror.
+
+### External
+`sqlalchemy`, `pydantic`, `pyarrow`, `boto3`, `pandas`, `openai`, `sentence-transformers`,
+`snorkel`, `google-play-scraper`, `konlpy`, `uuid6`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/crawlers/AGENTS.md
+++ b/src/crawlers/AGENTS.md
@@ -1,0 +1,66 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/crawlers
+
+## Purpose
+Bronze-layer ingestion. Each crawler pulls reviews for its store's app-id list, converts the raw API
+payload into `AppReviewSchema` records, writes them as Parquet to MinIO, and registers an
+`ingestion_batch` row in `PENDING`. Crawlers never write `review_master_index` — that is the load
+stage's job (`src/loaders/`), which keeps crawl failures isolated from DB state.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `base_crawler.py` | `BaseCrawler(ABC)`: config/app-id loading, request pacing, `collect_app_records()`, `save_crawl_batch()`, `save_daily_batch()`, `run()` template. Owns Parquet format consistency for all stores |
+| `appstore_crawler.py` | `AppStoreCrawler`: App Store RSS/API via `requests`; app-id file from `config.app_ids.appstore` |
+| `playstore_crawler.py` | `PlayStoreCrawler`: `google_play_scraper.reviews` + `app`; app-id file from `config.app_ids.playstore` |
+| `unified_crawler.py` | `UnifiedCrawler`: runs both stores sequentially, catching each store's failure so one store cannot abort the other. Deliberately **not** a `BaseCrawler` subclass |
+| `exceptions.py` | `ParquetWriteError` — Parquet write failure during the crawl stage |
+| `__init__.py` | `Store` enum (`appstore` / `playstore` / `unified`) and the `get_crawler(store, config_path)` factory |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- New stores subclass `BaseCrawler` and implement `crawl_reviews(app_id)`; register them in the
+  `Store` enum and `get_crawler()`. Parquet schema consistency comes from the base class — do not
+  write Parquet directly from a store crawler.
+- `UnifiedCrawler` is an orchestrator, not a crawler. Keep it out of the `BaseCrawler` hierarchy.
+- Parquet upload plus `ingestion_batch` registration can be disabled with `ENABLE_PARQUET_WRITE=false`
+  (see `.env.example`); code paths must tolerate that flag.
+- Request pacing comes from `crawler_config.yml` `global.delay_between_requests` /
+  `max_retries` / `timeout`. Never hardcode sleeps or retry counts.
+- A `ParquetWriteError` must fail the crawl for that batch rather than silently continuing — a
+  registered batch with no Parquet object would strand the loader.
+- Logs in this package are Korean and use emoji markers (🍎 / 🤖 / ✅ / ❌); match that style.
+
+### Testing Requirements
+`tests/test_crawler_consistency.py` asserts App Store and Play Store crawlers emit structurally
+identical records; `tests/test_bronze_loading.py` covers the Parquet → DB handoff.
+`tests/conftest.py` provides `mock_appstore_api` (requests_mock) and `mock_playstore_api`
+(monkeypatched scraper) plus `sample_app_id_file` — use them instead of hitting live stores.
+
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_crawler_consistency.py tests/test_bronze_loading.py -q
+```
+
+### Common Patterns
+- App-id files are read with `read_app_ids()`, which skips blank lines and `#` comments.
+- Review IDs are UUID v7 (`uuid6.uuid7`) so Bronze partitions stay time-ordered.
+- Timestamps are timezone-aware UTC (`datetime.now(timezone.utc)`).
+
+## Dependencies
+
+### Internal
+`src/utils/logger.py`, `src/utils/db_connector.py`, `src/utils/minio_client.py`,
+`src/utils/parquet_writer.py`, `src/schemas/parquet/app_review.py`,
+`src/models/ingestion_batch.py`, `config/app_ids/`, `config/crawler_config.yml`.
+
+### External
+`requests`, `google-play-scraper`, `pyarrow`, `boto3`, `uuid6`, `pyyaml`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/gold/AGENTS.md
+++ b/src/gold/AGENTS.md
@@ -1,0 +1,71 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/gold
+
+## Purpose
+Gold layer: turns cleansed Silver review text into analytics. Three analyzers run per review in a
+fixed order (embedding → ABSA → action analysis) under `GoldOrchestrator`, which owns the
+`CLEANED → ANALYZED | FAILED` state transition. `GoldAggregator` then rolls `ANALYZED` reviews into
+three fact tables plus one denormalized serving mart consumed by the dashboard backend.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `orchestrator.py` | `GoldOrchestrator.run(batch_size, limit, target_date)`. Selects `CLEANED` rows plus `FAILED` rows with `retry_count < 3`, runs the three analyzers, commits per chunk, and records `error_message` (truncated to 2000 chars) on failure |
+| `embedding_generator.py` | `GoldEmbeddingGenerator`: vectorizes `reviews_preprocessed.refined_text` into `review_embeddings` (default model `text-embedding-3-small`) |
+| `absa_analyzer.py` | `GoldABSAAnalyzer`: keyword/sentiment/category extraction into `review_aspects`. `S_final = S_base × W_adv`, negation flips to `1.0 - S_final`, range 0.0–1.0. Category resolution is rule-based first, then embedding cosine similarity ≥ 0.8, else unclassified |
+| `action_analyzer.py` | `GoldActionAnalyzer`: `is_attention_required` rules (rating ≥ 4 with sentiment < 0.4, or rating ≤ 2 with sentiment > 0.6) and `is_action_required` via Snorkel labeling functions + `MajorityLabelVoter`, plus a one-sentence LLM summary into `review_action_analysis` |
+| `aggregator.py` | `GoldAggregator.run(target_date, retention_days=14)`, `run_range(start_date, end_date)`, `run_all()`. UPSERTs `fact_service_review_daily`, `fact_service_aspect_daily`, `fact_category_radar_scores`, `srv_daily_review_list` |
+| `__init__.py` | Package marker only — no re-exports, so import modules directly |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Analyzer order in `_process_one` is a real dependency chain: ABSA's embedding-similarity category
+  fallback needs the embedding row to already exist. Do not reorder or parallelize it.
+- Each analyzer exposes both `process(session, review_id) -> bool` (orchestrated, shares the caller's
+  session/transaction) and `process_batch(batch_size, limit)` (standalone). Add new analyzers with
+  both entry points.
+- Returning `False` from `process()` is treated as failure — the orchestrator raises, marks the row
+  `FAILED`, and increments `retry_count`. Never swallow an analyzer error into a `True` return.
+- `_MAX_RETRY = 3` in `orchestrator.py:26` is the retry ceiling; rows past it are the review-level
+  dead letters queried by `src/pipeline/failures.py`.
+- Aggregation must stay idempotent (UPSERT) — Airflow retries and manual backfills re-run the same
+  date. `srv_daily_review_list` is range-partitioned by `date`; partitions must exist beforehand.
+- Scheduled runs aggregate a single date; `run_range` exists only for manual repair
+  (`docs/superpowers/specs/2026-04-18-aggregate-range-backfill-design.md`).
+- ABSA yielding zero aspects must not orphan or drop mart rows — that regression is covered by the
+  `absa-orphan-integrity` fixes; keep the tests that pin it.
+- Embedding and LLM summary calls require a live `OPENAI_API_KEY`.
+
+### Testing Requirements
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" PYTHONPATH=. uv run pytest \
+  tests/test_gold_orchestrator.py tests/test_gold_absa_analyzer.py \
+  tests/test_gold_action_analyzer.py tests/test_gold_embedding_generator.py \
+  tests/test_gold_aggregator.py tests/test_backend_datamart_contract.py -q
+```
+Mart output must also satisfy `docs/backend-datamart-contract.md`.
+
+### Common Patterns
+- Analyzer modules are imported lazily inside `GoldOrchestrator.__init__` to isolate heavy optional
+  dependencies (torch/transformers/snorkel/openai) from unrelated pipeline steps.
+- The orchestrator commits once per `batch_size` chunk and rolls back the whole batch on an
+  unexpected exception.
+
+## Dependencies
+
+### Internal
+`src/models/` (`review_master_index`, `review_aspects`, `review_embedding`,
+`review_action_analysis`, `fact_*`, `srv_daily_review_list`), `src/utils/db_connector.py`,
+`src/utils/logger.py`, `src/processing/cleanse.py` output.
+
+### External
+`openai`, `sentence-transformers`, `transformers`, `torch`, `snorkel`, `scikit-learn`, `pgvector`,
+`sqlalchemy`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/loaders/AGENTS.md
+++ b/src/loaders/AGENTS.md
@@ -1,0 +1,55 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/loaders
+
+## Purpose
+Load stage: the bridge from Bronze Parquet to PostgreSQL. Reads `ingestion_batch` rows in
+`PENDING` / `FAILED`, fetches each batch's Parquet object, and inserts the reviews into
+`review_master_index` with `processing_status = RAW`, then advances the batch status. This is the
+only place where crawled objects become durable DB state.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `batch_loader.py` | `BatchLoader.load_pending_batches(limit=100)` — batch selection, Parquet read, dedup against existing reviews, `review_master_index` insert, batch status transition, retry/dead-letter handling |
+| `__init__.py` | Re-exports `BatchLoader` |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Batch status is the source of truth for ingestion failures: exhausted batches become
+  `DEAD_LETTER` and are queried by `src/pipeline/failures.py:fetch_batch_dead_letters`. There is
+  deliberately no separate row-level DLQ table (`docs/pipeline-failure-policy.md`).
+- Loading must be idempotent — a re-run of the same batch must not duplicate
+  `review_master_index` rows. Preserve the existing dedup on platform review identity.
+- `PendingRollbackError` is handled explicitly; when adding DB work, keep failures scoped so one bad
+  batch does not poison the session for the remaining batches.
+- The loader owns only Bronze → index. Text cleansing belongs in `src/processing/`, analytics in
+  `src/gold/`.
+
+### Testing Requirements
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_batch_loader.py tests/test_bronze_loading.py -q
+```
+`tests/conftest.py` supplies `db_with_pending_batches` and `db_with_failed_batches`, which write
+real Parquet files into a temp Bronze directory — use them rather than stubbing the reader.
+
+### Common Patterns
+Raw SQL via `sqlalchemy.text` is used where bulk UPSERT semantics matter; UUIDs and timezone-aware
+UTC timestamps everywhere.
+
+## Dependencies
+
+### Internal
+`src/models/ingestion_batch.py`, `src/models/review_master_index.py`, `src/models/enums.py`,
+`src/utils/db_connector.py`, `src/utils/minio_client.py`, `src/schemas/parquet/app_review.py`.
+
+### External
+`sqlalchemy`, `pyarrow`, `boto3`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/models/AGENTS.md
+++ b/src/models/AGENTS.md
@@ -1,0 +1,78 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/models
+
+## Purpose
+SQLAlchemy ORM models mirroring `sql/schema_v4.sql`, organized by medallion layer. One declarative
+`Base` and one central ENUM module keep type definitions from drifting across files. Some models
+(`Review`, `ReviewPreprocessed`) exist mainly as structural documentation of tables whose payload
+actually lives in Parquet.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `base.py` | The single `declarative_base()` every model inherits |
+| `enums.py` | Central ENUMs: `PlatformType`, `AppType`, `ProcessingStatusType`, `AnalysisStatusType`, `SentimentType`, `IngestionBatchStatusType`, `CategoryType` |
+| `__init__.py` | Package version (`5.0.0`) and the curated re-export list grouped by layer |
+| `app_service.py` | `AppService` — logical service master (39 rows) |
+| `apps.py` | `App` — physical app instance per platform (63 rows) |
+| `app_metadata.py` | `AppMetadata` — app ↔ service link with SCD Type 2 history (`valid_from`/`valid_to`/`is_active`) |
+| `organizations.py` | `Organization` — 114-row org hierarchy. **Docstring claims `ltree`, but the DDL has none**: `org_id` is plain `TEXT` with hyphen levels (`1`, `1-1`, `10-5`). ltree was removed in issue #32 |
+| `review_master_index.py` | `ReviewMasterIndex` — central hub across Bronze → Silver → Gold; carries `processing_status`, `retry_count`, `error_message` |
+| `ingestion_batch.py` | `IngestionBatch` — Parquet batch ingestion state and batch-level DLQ |
+| `review.py` | `Review` — Bronze raw review (stored as Parquet, not queried in DB) |
+| `review_preprocessed.py` | `ReviewPreprocessed` — Silver cleansed text (stored as Parquet) |
+| `review_embedding.py` | `ReviewEmbedding` — pgvector embedding column |
+| `review_aspects.py` | `ReviewAspect` — ABSA keyword/sentiment/category rows |
+| `review_action_analysis.py` | `ReviewActionAnalysis` — Snorkel actionability results and LLM summary |
+| `llm_analysis_log.py` | `LLMAnalysisLog` — LLM call audit trail with JSONB payload |
+| `review_assigned.py` | `ReviewAssigned` — final department assignment (Gold) |
+| `fact_service_review_daily.py` | `FactServiceReviewDaily` — service × platform × date review counts and averages |
+| `fact_service_aspect_daily.py` | `FactServiceAspectDaily` — service × date × keyword mentions and sentiment |
+| `fact_category_radar_scores.py` | `FactCategoryRadarScores` — service × date × `CategoryType` radar scores (USABILITY / STABILITY / DESIGN / CUSTOMER_SUPPORT / SPEED) |
+| `srv_daily_review_list.py` | `SrvDailyReviewList` — denormalized wide serving mart, `PARTITION BY RANGE(date)`; partitions must pre-exist |
+| `dictionary.py` | `Synonym`, `Profanity`, `FinancialTerm` reference tables |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- **Never define an enum locally.** Import from `enums.py`; duplicated enum types break the
+  PostgreSQL type mapping.
+- These models do not create the schema. DDL comes from `sql/schema_v4.sql` plus Alembic revisions —
+  editing a model does not migrate anything, and `alembic --autogenerate` is disabled because model
+  metadata is not yet lossless against the baseline.
+- Adding a model means adding the import **and** the `__all__` entry in `__init__.py`; several
+  modules rely on `from src.models import X`.
+- `Review` and `ReviewPreprocessed` describe Parquet-resident tables; do not add query paths that
+  assume their rows are populated in PostgreSQL.
+- `ReviewEmbedding` requires `pgvector`, which is why tests need `pgvector/pgvector:pg17` rather than
+  plain PostgreSQL. `Organization`'s docstring still claims the `ltree` extension, but
+  `schema_v4.sql` contains zero `ltree` references — treat the docstring as stale.
+
+### Testing Requirements
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_enums.py tests/test_database_schema.py -q
+```
+Any model change must also be checked against `sql/schema_v4.sql` and the mart contract in
+`docs/backend-datamart-contract.md`.
+
+### Common Patterns
+Korean module docstring plus English body comments; `Column(UUID(as_uuid=True))` for identifiers,
+`Enum as SQLEnum` bound to the central enums, `server_default=func.now()` for audit timestamps.
+
+## Dependencies
+
+### Internal
+`sql/schema_v4.sql` (authoritative DDL), `alembic/versions/`, consumed by `src/loaders/`,
+`src/gold/`, `src/pipeline/`, and `tests/`.
+
+### External
+`sqlalchemy`, `pgvector.sqlalchemy` (optional import guard), PostgreSQL dialect types
+(`UUID`, `JSONB`, `ARRAY`).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/pipeline/AGENTS.md
+++ b/src/pipeline/AGENTS.md
@@ -1,0 +1,74 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/pipeline
+
+## Purpose
+The orchestration seam. Wraps every stage in a uniform `run_*() -> RunResult` function so the CLI,
+Airflow, and tests all drive the same code path; owns argument parsing, sequential step execution
+with fail-fast semantics, post-aggregate DB validation, and the operational queries for
+retry-exhausted work.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `steps.py` | `RunResult` dataclass and the step wrappers `run_crawl`, `run_load`, `run_preprocess` (deprecated), `run_extract_features`, `run_action_analysis`, `run_generate_embeddings`, `run_gold`, `run_aggregate`, `run_post_aggregate_validation`, plus `run_steps()` which stops at the first non-success step |
+| `cli.py` | argparse entrypoint: `--steps`, `--batch-size`, `--limit`, `--model-name`, `--config`, `--target-date`. Loads `.env` if present, logs each `RunResult`, returns 1 on the first failure |
+| `post_aggregate_validation.py` | `PostAggregateValidator.validate(target_date)` → `ValidationReport` of `ValidationCheck`s with severity `failure` / `warning` / `report` |
+| `failures.py` | `fetch_review_dead_letters()` (FAILED with `retry_count >= 3`) and `fetch_batch_dead_letters()` (`ingestion_batch` `DEAD_LETTER`), plus the equivalent raw SQL constants |
+| `validation.py` | `make_count_validation(input_count, output_count)` — simple row-count delta metrics |
+| `__init__.py` | Re-exports `RunResult` and the crawl/preprocess/features/embeddings/run_steps helpers |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Steps return failures as `RunResult(status="failed", message=...)`; they do not raise. `_handle_step`
+  catches everything and logs with `logger.exception`. Preserve that contract — Airflow and the CLI
+  map status to the exit code.
+- Registering a new step means adding it to the `step_funcs` dict in `run_steps()` **and** to the
+  `--steps` help text in `cli.py`. An unrecognized step yields `"unknown step"` and halts the run.
+- `post_aggregate_validate` and `validate` are aliases for the same validator. Both require
+  `--target-date`; the empty-string fallback (`target_date or ""`) surfaces as a parse failure
+  rather than silently validating today.
+- Date parsing is centralized in `_parse_date_arg` (`%Y-%m-%d`); `cli.py` additionally validates
+  `--target-date` at parse time via `date.fromisoformat`.
+- `run_aggregate` rejects `target_date` combined with `start_date`/`end_date`, and requires
+  `start_date`/`end_date` together. Keep those guards.
+- Heavy modules are imported **inside** each step function so that, for example, `run_crawl` works
+  without torch installed. Do not hoist those imports to module scope.
+- `run_preprocess` is deprecated: it emits a `DeprecationWarning` and returns failure. Route
+  cleansing through `scripts/cleanse_reviews.py`.
+- Severity policy in the validator is deliberate — zero new reviews is a `warning`/`report`, while
+  broken state transitions, mart gaps, and integrity violations are `failure` and fail the DAG
+  (`docs/airflow-continuous-load-readiness.md`).
+
+### Testing Requirements
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" PYTHONPATH=. uv run pytest \
+  tests/test_pipeline_steps.py tests/test_cli_parsing.py tests/test_pipeline_cli_validation.py \
+  tests/test_pipeline_failures.py tests/test_post_aggregate_validation.py \
+  tests/test_pipeline_integration.py -q
+```
+
+### Common Patterns
+```python
+def run_x(...) -> RunResult:
+    from src.somewhere import Thing          # lazy import
+    return _handle_step("x", lambda: Thing(config_path).do())
+```
+Validation checks are dataclasses with `as_dict()` so reports serialize straight into
+`RunResult.validations` and the CLI's JSON log line.
+
+## Dependencies
+
+### Internal
+`src/crawlers/`, `src/loaders/`, `src/gold/`, `src/models/` (enums, `ingestion_batch`,
+`review_master_index`), `src/utils/db_connector.py`, `src/utils/logger.py`.
+
+### External
+`sqlalchemy`, `python-dotenv`; stdlib `argparse`, `dataclasses`, `json`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/processing/AGENTS.md
+++ b/src/processing/AGENTS.md
@@ -1,0 +1,60 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/processing
+
+## Purpose
+Bronze → Silver cleansing (issue #14). Normalizes raw Korean review text into `refined_text`:
+Unicode normalization, emoji removal, repeated-character reduction, special-character stripping,
+whitespace collapsing, PII masking, profanity tagging, and synonym canonicalization. Output is
+written as Silver Parquet and the review's `processing_status` advances `RAW → CLEANED`.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `cleanse.py` | Text primitives (`normalize_unicode`, `remove_emojis`, `reduce_repeated_chars`, `remove_special_chars`, `normalize_whitespace`, `mask_pii`), the `ReviewCleaner.clean(text)` rule engine, Parquet IO (`load_bronze_parquet`, `write_silver_parquet`), and `ReviewCleaningPipeline.run(target_date)` |
+| `__init__.py` | Empty package marker — import `src.processing.cleanse` directly |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- The pipeline is date-scoped: `run(target_date)` processes one Bronze partition. The Airflow task
+  passes `{{ ds }}` through `scripts/cleanse_reviews.py --date`.
+- Dictionaries are injected as paths (`synonyms_path`, `profanity_path`), not read from a global —
+  `scripts/cleanse_reviews.py` supplies `config/dictionaries/*.json`. Keep them parameters so tests
+  can pass temp files.
+- Text rules are ordered; changing the order changes the output (for example, emoji removal before
+  whitespace normalization). Add a regression test with any reordering.
+- PII masking is a correctness requirement, not a nicety — masked values must never be reversible
+  back into Silver output.
+- `run_preprocess` in `src/pipeline/steps.py` is the deprecated predecessor of this module; it warns
+  and returns failure. Do not route new work through it.
+
+### Testing Requirements
+`tests/test_cleanse.py` is the largest single test module (~28 KB) and builds temporary
+synonym/profanity JSON files per test.
+
+```bash
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest tests/test_cleanse.py -q
+```
+
+### Common Patterns
+Pure functions for each text rule, composed by `ReviewCleaner.clean()`; the pipeline class owns IO
+and DB state so the rule layer stays trivially testable.
+
+## Dependencies
+
+### Internal
+`config/dictionaries/synonyms.json`, `config/dictionaries/profanity.json`,
+`src/models/review_master_index.py`, `src/schemas/parquet/review_preprocessed.py`,
+`src/utils/minio_client.py`, `src/utils/parquet_writer.py`.
+
+### External
+`emoji`, `flashtext`, `konlpy`, `nltk`, `pyarrow`, `sqlalchemy` (stdlib `re` / `unicodedata` for the
+core rules).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/schemas/AGENTS.md
+++ b/src/schemas/AGENTS.md
@@ -1,0 +1,46 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/schemas
+
+## Purpose
+Pydantic validation layer for data that leaves the database — primarily Parquet payloads written to
+MinIO/NAS. Keeping validation here (rather than in the ORM) means Bronze and Silver files are
+schema-checked at write time even though no database constraint protects them.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `__init__.py` | Convenience re-exports of `AppReviewSchema` and `ReviewPreprocessedSchema` |
+
+## Subdirectories
+| Directory | Purpose |
+|-----------|---------|
+| `parquet/` | Bronze/Silver Parquet schemas and shared UUID/timestamp helpers (see `parquet/AGENTS.md`) |
+
+## For AI Agents
+
+### Working In This Directory
+- This package validates *file* payloads; database structure is owned by `src/models/` and
+  `sql/schema_v4.sql`. A field added to one must be mirrored in the other deliberately.
+- Keep the top-level re-exports in sync when adding a schema, since call sites use
+  `from src.schemas import ...` as well as the fully qualified path.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run pytest tests/test_parquet_schemas.py -q
+```
+
+### Common Patterns
+Pydantic v2 `BaseModel` with `ConfigDict`, `Field`, and `@field_validator`; defaults are produced by
+factory helpers (`generate_uuid_v7`, `utc_now`) rather than mutable literals.
+
+## Dependencies
+
+### Internal
+Used by `src/crawlers/`, `src/processing/`, `src/loaders/`, and `src/utils/parquet_writer.py`.
+
+### External
+`pydantic`, `uuid6`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/schemas/parquet/AGENTS.md
+++ b/src/schemas/parquet/AGENTS.md
@@ -1,0 +1,56 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/schemas/parquet
+
+## Purpose
+Pydantic schemas for the Parquet files that hold Bronze and Silver review data on MinIO/NAS. They
+mirror the corresponding `schema_v4.sql` table structures and are the only validation those files
+get, since no database constraint applies to object storage.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `app_review.py` | `AppReviewSchema` (alias `AppReview`) — Bronze raw review: `app_id`, `platform_type`, `platform_review_id`, `review_text`, `rating`, `reviewed_at`. Mirrors `app_reviews` |
+| `review_preprocessed.py` | `ReviewPreprocessedSchema` (alias `ReviewPreprocessed`) — Silver cleansed review: `review_id`, `platform_review_id`, `refined_text`. Mirrors `reviews_preprocessed` |
+| `base.py` | Shared helpers: `generate_uuid_v7()` (time-sortable IDs for better index locality), `utc_now()`, `to_utc()` |
+| `__init__.py` | Layer-annotated re-exports plus a doctest-style usage example |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- Field changes are a Parquet format change. Existing objects in MinIO were written with the old
+  shape, so adding a required field breaks reads of historical partitions — add optional fields with
+  defaults, or plan a rewrite.
+- Keep these schemas aligned with `sql/schema_v4.sql` and the ORM models in `src/models/review.py` /
+  `src/models/review_preprocessed.py`; the three describe the same data in different media.
+- Timestamps must be timezone-aware UTC. Use `utc_now()` / `to_utc()` instead of naive
+  `datetime.now()`.
+- IDs are UUID v7 via `generate_uuid_v7()` so Bronze partitions stay time-ordered — do not swap in
+  `uuid4`.
+- Schema class and alias are both exported (`AppReviewSchema` / `AppReview`); keep both when
+  renaming, since call sites use each.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run pytest tests/test_parquet_schemas.py tests/test_parquet_writer.py -q
+```
+`tests/test_crawler_consistency.py` also depends on this shape being identical across stores.
+
+### Common Patterns
+Pydantic v2 `BaseModel` with `ConfigDict`, `Field(default_factory=...)` for generated values, and
+`@field_validator` for normalization (for example coercing timestamps to UTC).
+
+## Dependencies
+
+### Internal
+`src/crawlers/base_crawler.py` (Bronze writes), `src/processing/cleanse.py` (Silver writes),
+`src/loaders/batch_loader.py` (reads), `src/utils/parquet_writer.py`.
+
+### External
+`pydantic`, `uuid6`, `pyarrow` (at the writer boundary).
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/src/utils/AGENTS.md
+++ b/src/utils/AGENTS.md
@@ -1,0 +1,63 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# src/utils
+
+## Purpose
+Shared infrastructure used by every pipeline stage: logging, database sessions, object storage,
+Parquet IO, and environment-aware path resolution. Nothing here knows about reviews — these modules
+stay domain-agnostic so stage code can depend on them without coupling.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `logger.py` | Singleton `Logger` loading `config/logging_config.yml`; creates `logs/{crawler,error,debug}` and falls back to `basicConfig` if the YAML fails. Public entry: `get_logger(name)` |
+| `db_connector.py` | `DatabaseConnector(config_path)` — builds the SQLAlchemy engine from `DATABASE_URL`, exposes `get_session()`, `get_autocommit_connection()`, `create_tables(base)` |
+| `minio_client.py` | `MinIOClient` (boto3 S3): `list_objects`, `get_parquet`, `put_parquet`, `delete_object`. Works against MinIO or native AWS S3 depending on `MINIO_ENDPOINT` |
+| `parquet_writer.py` | `ParquetWriter`: `write_batch`, `write_single`, `append_to_partition`, `list_partitions`, `get_partition_stats`, plus `read_parquet_to_schemas()` for reading back into Pydantic models |
+| `path_resolver.py` | `PathResolver` with `${VARIABLE}` substitution over `config/paths.yml`; helpers `get_resolver()`, `resolve_path()`, `get_medallion_paths()` |
+| `file_manager.py` | Local filesystem helper (`ensure_directories`, `get_output_path`, `save_reviews`, `backup_file`, `list_files`, `cleanup_old_files`) for the legacy CSV output path |
+| `data_processor.py` | Pandas-based transforms between raw review dicts and `Review` records |
+| `__init__.py` | Package version marker only (`1.0.0`) — import modules directly |
+
+## Subdirectories
+None.
+
+## For AI Agents
+
+### Working In This Directory
+- These modules must not import from `src/crawlers/`, `src/gold/`, `src/loaders/`, or
+  `src/processing/`. Utilities depend downward only (`src/models/`, `src/schemas/`).
+- Paths come from `config/paths.yml` through `PathResolver`, driven by `PARQUET_BASE_PATH`. Do not
+  hardcode `data/`, `/mnt/nas/...`, or bucket prefixes at call sites.
+- `MINIO_ENDPOINT` selects the backend: `host:9000` (no scheme) targets MinIO, unset/empty targets
+  native AWS S3 with IAM credentials. `MINIO_USE_SSL` must be `true` in production.
+- `logger.py` reads `config/logging_config.yml`, not `config/logging.yml`; the latter is an
+  unreferenced duplicate.
+- The logger is a module-level singleton instantiated at import time and creates log directories as
+  a side effect — keep that in mind when writing tests that assert on the filesystem.
+- `file_manager.py` and `data_processor.py` serve the older CSV/DataFrame path; new work should go
+  through `parquet_writer.py` + `minio_client.py`.
+
+### Testing Requirements
+```bash
+PYTHONPATH=. uv run pytest tests/test_path_resolver.py tests/test_parquet_writer.py tests/test_minio_client.py -q
+```
+`tests/conftest.py` provides `temp_dir`, `temp_parquet_dir`, and `temp_bronze_dir` so tests write to
+throwaway directories instead of the configured medallion paths.
+
+### Common Patterns
+- `get_logger(__name__)` at module scope in every consumer.
+- Sessions are opened by the caller and closed in `finally`; `DatabaseConnector` does not manage
+  transaction scope for you.
+- Environment reads use `os.getenv(NAME, default)` with the default documented in `.env.example`.
+
+## Dependencies
+
+### Internal
+`config/logging_config.yml`, `config/paths.yml`, `src/schemas/parquet/`, `src/models/review.py`.
+
+### External
+`sqlalchemy`, `psycopg2-binary`, `boto3`, `pyarrow`, `pandas`, `pyyaml`, `python-dotenv`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,81 @@
+<!-- Parent: ../AGENTS.md -->
+<!-- Generated: 2026-08-10T08:45:46Z | Updated: 2026-08-10T08:45:46Z -->
+
+# tests
+
+## Purpose
+Flat pytest suite covering every pipeline stage against a **real PostgreSQL** database. There is no
+SQLite fallback and no mocked database layer — the schema is initialized from `sql/schema_v4.sql`
+so pgvector, enums, partitions, and constraints are all exercised. Only external HTTP APIs
+(App Store RSS, google-play-scraper) are stubbed.
+
+## Key Files
+| File | Description |
+|------|-------------|
+| `conftest.py` | Shared infrastructure: session-scoped engine/schema, function-scoped rollback session, temp Parquet dirs, sample review payloads, pre-populated DB states, API stubs, marker registration |
+| `test_backend_datamart_contract.py` | Backend-facing mart contract for the four Gold tables (largest suite) |
+| `test_backend_datamart_serving_readiness.py` | Serving-readiness evidence checks for the mart |
+| `test_post_aggregate_validation.py` | `PostAggregateValidator` checks, severities, and report shape |
+| `test_cleanse.py` | Bronze → Silver cleansing rules, dictionaries, PII masking |
+| `test_gold_absa_analyzer.py` | Keyword/sentiment/category extraction, negation, embedding fallback |
+| `test_gold_action_analyzer.py` | Attention/action rules, Snorkel labeling functions, LLM summary |
+| `test_gold_aggregator.py` | Fact table + serving mart UPSERT semantics |
+| `test_gold_embedding_generator.py` | Embedding generation and persistence |
+| `test_gold_orchestrator.py` | CLEANED → ANALYZED/FAILED state machine and retry policy |
+| `test_batch_loader.py` | Pending/failed batch consumption into `review_master_index` |
+| `test_bronze_loading.py` | Bronze Parquet → DB load integration |
+| `test_crawler_consistency.py` | App Store vs Play Store crawler output parity |
+| `test_database_schema.py` | Schema objects created by `schema_v4.sql` |
+| `test_parquet_schemas.py` / `test_parquet_writer.py` | Pydantic Parquet schemas and writer partitioning |
+| `test_path_resolver.py` | `${VAR}` substitution and medallion path resolution |
+| `test_minio_client.py` | MinIO/S3 wrapper behavior |
+| `test_pipeline_steps.py` / `test_pipeline_failures.py` / `test_pipeline_integration.py` | Step dispatch, dead-letter queries, end-to-end wiring |
+| `test_cli_parsing.py` / `test_pipeline_cli_validation.py` | argparse contract and `--target-date` validation |
+| `test_bootstrap_db.py` / `test_alembic_config.py` / `test_local_dev_setup.py` / `test_ci_workflows.py` | Bootstrap, migration config, compose files, and GitHub workflow contract |
+| `test_airflow_dag_validation_wiring.py` / `test_airflow_readiness_docs.py` | DAG wiring and readiness-doc contract |
+| `test_enums.py` | Central ENUM definitions |
+
+## Subdirectories
+None — the suite is intentionally flat, one `test_<module>.py` per source module.
+
+## For AI Agents
+
+### Working In This Directory
+- `test_db_url` resolves `TEST_DATABASE_URL`, defaulting to
+  `postgresql://testuser:testpass@localhost:${TEST_POSTGRES_PORT:-5433}/testdb`. The schema fixture
+  runs `DROP SCHEMA public CASCADE` — **never** point it at a production database.
+- The image must be `pgvector/pgvector:pg17` (or equivalent); `schema_v4.sql` requires the `vector`
+  extension.
+- `test_db_session` is function-scoped and rolls back, so tests must not rely on committed state
+  from a previous test; use `db_with_apps`, `db_with_failed_reviews`, `db_with_pending_batches`, or
+  `db_with_failed_batches` to seed.
+- Do not introduce database mocks or in-memory substitutes to make a test pass — the suite's value
+  is that it runs against the real schema.
+- There is no `[tool.pytest.ini_options]` section in `pyproject.toml`; markers are registered in
+  `pytest_configure` at `conftest.py:619`.
+
+### Testing Requirements
+```bash
+docker compose -f docker-compose.test.yml up -d test-postgres
+TEST_DATABASE_URL="postgresql://testuser:testpass@localhost:5433/testdb" \
+  PYTHONPATH=. uv run pytest            # full suite
+PYTHONPATH=. uv run pytest -m "not requires_db"   # DB-free subset
+```
+Markers: `slow`, `integration`, `requires_db`.
+
+### Common Patterns
+- `@pytest.mark.requires_db` on anything touching PostgreSQL.
+- Fixtures return live `Session` objects; assertions query through the ORM models in `src/models/`.
+- Sample crawler payloads mirror the real upstream response shapes (App Store RSS entries,
+  google-play-scraper dicts) so schema drift is caught at the boundary.
+
+## Dependencies
+
+### Internal
+`src/models/`, `src/schemas/parquet/`, `sql/schema_v4.sql`, `docker-compose.test.yml`,
+`config/dictionaries/`.
+
+### External
+`pytest`, `sqlalchemy`, `uuid6`, `requests_mock` (used by `mock_appstore_api`), `pyarrow`.
+
+<!-- MANUAL: Notes added below this line are preserved on regeneration -->


### PR DESCRIPTION
## Summary

디렉터리마다 `AGENTS.md`를 하나씩 두어(28개) 에이전트와 신규 기여자가 구조를 매번 다시 파악하지 않아도 되게 합니다. 루트를 제외한 모든 파일이 `<!-- Parent: ../AGENTS.md -->` 역참조를 갖는 트리 구조입니다.

각 파일은 목적 · 주요 파일 · 하위 디렉터리 · 작업 시 주의사항 · 테스트 방법 · 의존성을 담습니다.

## Changes

- `AGENTS.md` 28개 신규 (루트 1 / L1 9 / L2 14 / L3 4)
- `.gitignore`에 `!AGENTS.md` 추가

`.gitignore`가 `*.md`를 통째로 무시하고 `!README.md`만 예외로 두고 있어, 그대로 두면 **28개 파일이 전부 git에 보이지 않습니다.** 기존 `docs/*.md`가 추적되는 건 과거에 force-add된 결과입니다.

## 작성 중 확인한 사실 (코드 대조 완료)

문서에 반영한 것들 중 코드를 봐야만 알 수 있는 항목입니다.

- `sql/schema_v4.sql`은 동결된 Alembic 베이스라인 — 스키마 변경은 새 리비전으로
- Alembic autogenerate는 의도적으로 비활성 (`target_metadata = None`, ORM 메타데이터가 베이스라인과 lossless하지 않아서)
- `config/logging.yml`은 어떤 코드도 참조하지 않음 — 실사용은 `logging_config.yml` (`logger.py:30`)
- `organizations`는 ltree가 아니라 plain `TEXT` `org_id` (#32에서 제거). 모델 docstring은 아직 ltree라고 주장하므로 stale로 표기
- `src/`에 `__init__.py`가 없음 — 네임스페이스 패키지로 `PYTHONPATH=.` 전제

## Validation

```text
parent-check-failures=0
total AGENTS.md: 28
files with Generated header: 28 / 28
files with MANUAL block:     28 / 28
```

- 28개 전부 부모 참조가 실제 파일로 해석됨 (루트는 태그 없음)
- 고아 파일 없음 (모든 AGENTS.md의 디렉터리가 존재)
- 제외 디렉터리(node_modules·.git·__pycache__ 등) 외에 누락된 디렉터리 없음
- 각 파일 하단에 `<!-- MANUAL: -->` 블록을 두어 수동 추가분이 재생성 시 보존되도록 함

코드 변경이 없어 테스트에 영향을 주지 않습니다.

## Not tested

- 문서 전용 변경이라 pytest를 돌리지 않았습니다.
