### PR TITLE
chore: 로컬 postgres 호스트 포트를 POSTGRES_PORT로 설정 가능하게

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_PASSWORD: reai
       POSTGRES_INITDB_ARGS: "-E UTF8 --locale=C"
     ports:
-      - "5432:5432"
+      - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres-data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary

호스트에 PostgreSQL이 이미 5432를 점유하고 있으면 `docker compose up`이 실패합니다.

```text
Error response from daemon: failed to set up container networking:
failed to bind host port 0.0.0.0:5432/tcp: address already in use
```

지금까지는 호스트 서비스를 멈추는 것 외에 방법이 없었습니다. 용도를 모르는 시스템 서비스를 끄는 건 위험하므로, 포트를 환경변수로 뺐습니다.

## Changes

```yaml
- "${POSTGRES_PORT:-5432}:5432"
```

기본값이 5432라 기존 설정에는 영향이 없습니다.

```bash
POSTGRES_PORT=5434 docker compose up -d
```

`docker-compose.test.yml`은 이미 `TEST_POSTGRES_PORT`·`TEST_MINIO_API_PORT`에 같은 패턴을 쓰고 있어, 메인 파일을 그 관례에 맞추는 변경이기도 합니다.

## Validation

```text
POSTGRES_PORT=5434 docker compose up -d
reai-local-postgres  running  0.0.0.0:5434->5432/tcp
postgres healthy
```

이 상태로 bootstrap → crawl 687건 → load → cleanse → gold 전 구간을 실행해 정상 동작을 확인했습니다.

## Not tested

- 기본값(5432) 경로는 호스트 postgres가 점유 중이라 이 환경에서 확인하지 못했습니다. 값 미지정 시 기존과 동일한 문자열로 전개되므로 회귀 위험은 없습니다.