### PR TITLE
fix: 마트 테스트 대상 날짜를 오늘 기준 상대값으로 전환 (#104)

### DIFF
--- a/tests/test_backend_datamart_contract.py
+++ b/tests/test_backend_datamart_contract.py
@@ -7,7 +7,7 @@ or a SQLite fallback.
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from uuid import UUID
 
@@ -94,10 +94,17 @@ CONTRACT_TABLES = {
 }
 
 SERVICE_FK_TABLES = set(CONTRACT_TABLES)
-CONTRACT_TARGET_DATE = date(2026, 5, 2)
-CONTRACT_PARTITION_NAME = "srv_daily_review_list_contract_2026_05_02"
-READINESS_TARGET_DATE = date(2026, 5, 3)
-READINESS_PARTITION_NAME = "srv_daily_review_list_2026_05_03"
+# 대상 날짜는 오늘 기준 상대값이어야 한다. aggregate 스텝은 적재 직후
+# date.today() - retention_days(기본 14) 이전 파티션을 DROP 하므로, 고정 날짜는
+# 시간이 지나면 방금 쓴 파티션이 같은 실행 안에서 사라진다.
+# 오프셋 1~13 은 마트 테스트 전체가 나눠 쓴다(파일 간 날짜 충돌 방지).
+_TODAY = date.today()
+READINESS_TARGET_DATE = _TODAY - timedelta(days=2)
+CONTRACT_TARGET_DATE = _TODAY - timedelta(days=3)
+# contract_ 접두 파티션은 TTL 정규식(srv_daily_review_list_\d{4}_\d{2}_\d{2})에
+# 걸리지 않아 자동 DROP 대상이 아니다. 정리는 _cleanup_contract_probe 가 한다.
+CONTRACT_PARTITION_NAME = f"srv_daily_review_list_contract_{CONTRACT_TARGET_DATE:%Y_%m_%d}"
+READINESS_PARTITION_NAME = f"srv_daily_review_list_{READINESS_TARGET_DATE:%Y_%m_%d}"
 CONTRACT_DOC_MARKERS = {
     "## Contract boundary": "contract table list",
     "## Column contract matrices": "column contract section",
@@ -540,7 +547,8 @@ def _create_contract_partition(test_db_session) -> None:
             f"""
             CREATE TABLE IF NOT EXISTS public.{CONTRACT_PARTITION_NAME}
             PARTITION OF public.srv_daily_review_list
-            FOR VALUES FROM ('2026-05-02') TO ('2026-05-03')
+            FOR VALUES FROM ('{CONTRACT_TARGET_DATE.isoformat()}')
+                        TO ('{(CONTRACT_TARGET_DATE + timedelta(days=1)).isoformat()}')
             """
         )
     )
@@ -585,7 +593,14 @@ def _cleanup_contract_probe(test_db_session, *, service_id, review_id) -> None:
 
 
 def _insert_contract_rows(test_db_session, service_id, review_id) -> None:
-    reviewed_at = datetime(2026, 5, 2, 9, 30, tzinfo=timezone.utc)
+    reviewed_at = datetime(
+        CONTRACT_TARGET_DATE.year,
+        CONTRACT_TARGET_DATE.month,
+        CONTRACT_TARGET_DATE.day,
+        9,
+        30,
+        tzinfo=timezone.utc,
+    )
     test_db_session.execute(
         text(
             """
@@ -708,7 +723,14 @@ def _insert_readiness_upstream_rows(
     review_id,
     platform_review_id: str,
 ) -> None:
-    reviewed_at = datetime(2026, 5, 3, 9, 30, tzinfo=timezone.utc)
+    reviewed_at = datetime(
+        READINESS_TARGET_DATE.year,
+        READINESS_TARGET_DATE.month,
+        READINESS_TARGET_DATE.day,
+        9,
+        30,
+        tzinfo=timezone.utc,
+    )
     connection.execute(
         text(
             """

--- a/tests/test_backend_datamart_serving_readiness.py
+++ b/tests/test_backend_datamart_serving_readiness.py
@@ -7,7 +7,7 @@ assert backend-facing mart rows and semantics from PostgreSQL.
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -19,7 +19,10 @@ from uuid6 import uuid7
 from src.pipeline import cli as pipeline_cli
 
 
-TARGET_DATE = date(2026, 5, 3)
+# 오늘 기준 상대값. 파이프라인 CLI aggregate 는 적재 직후 파티션 TTL(기본 14일)을
+# 적용하므로, 고정 날짜는 시간이 지나면 방금 쓴 파티션이 같은 실행 안에서 DROP 된다.
+# 오프셋 1~13 은 마트 테스트 전체가 나눠 쓴다(파일 간 날짜 충돌 방지).
+TARGET_DATE = date.today() - timedelta(days=1)
 SERVICE_NAME = "Serving Readiness Bank"
 PLATFORM_REVIEW_PREFIX = "serving-readiness"
 MANUAL_PROOF_DOC = (
@@ -262,9 +265,10 @@ def _seed_analyzed_pipeline_rows(
     platform_review_ids,
 ) -> None:
     reviewed_at = [
-        datetime(2026, 5, 3, 9, 0, tzinfo=timezone.utc),
-        datetime(2026, 5, 3, 10, 0, tzinfo=timezone.utc),
-        datetime(2026, 5, 3, 11, 0, tzinfo=timezone.utc),
+        datetime(
+            TARGET_DATE.year, TARGET_DATE.month, TARGET_DATE.day, hour, 0, tzinfo=timezone.utc
+        )
+        for hour in (9, 10, 11)
     ]
     session.execute(
         text(

--- a/tests/test_pipeline_cli_validation.py
+++ b/tests/test_pipeline_cli_validation.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 from uuid import uuid4
 
 import pytest
@@ -9,8 +9,11 @@ from sqlalchemy import text
 from src.pipeline import cli as pipeline_cli
 
 
-CLI_WARNING_TARGET_DATE = date(2026, 5, 18)
-CLI_FAILURE_TARGET_DATE = date(2026, 5, 19)
+# 오늘 기준 상대값. 고정 날짜는 파티션 TTL(기본 14일) 밖으로 밀려나 마트 검증이
+# 시간이 지난 뒤 깨진다. 오프셋 1~13 은 마트 테스트 전체가 나눠 쓴다.
+_TODAY = date.today()
+CLI_WARNING_TARGET_DATE = _TODAY - timedelta(days=12)
+CLI_FAILURE_TARGET_DATE = _TODAY - timedelta(days=13)
 
 
 def _target_datetime(target_date: date) -> datetime:

--- a/tests/test_post_aggregate_validation.py
+++ b/tests/test_post_aggregate_validation.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from datetime import date, datetime, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import text
@@ -10,14 +10,19 @@ from uuid6 import uuid7
 from src.pipeline.steps import run_aggregate, run_post_aggregate_validation
 
 
-SUCCESS_TARGET_DATE = date(2026, 5, 10)
-WARNING_ONLY_TARGET_DATE = date(2026, 5, 11)
-PENDING_BATCH_TARGET_DATE = date(2026, 5, 12)
-FAILED_REVIEW_TARGET_DATE = date(2026, 5, 13)
-MISSING_MAPPING_TARGET_DATE = date(2026, 5, 14)
-ORPHAN_TARGET_DATE = date(2026, 5, 15)
-MART_MISSING_TARGET_DATE = date(2026, 5, 16)
-COUNT_MISMATCH_TARGET_DATE = date(2026, 5, 17)
+# 대상 날짜는 오늘 기준 상대값이어야 한다. GoldAggregator 는 적재 직후
+# _drop_old_partitions() 로 date.today() - retention_days(기본 14) 이전 파티션을
+# DROP 하므로, 고정 날짜를 쓰면 시간이 지난 뒤 방금 쓴 파티션이 같은 실행 안에서
+# 사라진다. 오프셋은 마트 테스트 전체가 1~13 을 나눠 쓴다(파일 간 날짜 충돌 방지).
+_TODAY = date.today()
+SUCCESS_TARGET_DATE = _TODAY - timedelta(days=4)
+WARNING_ONLY_TARGET_DATE = _TODAY - timedelta(days=5)
+PENDING_BATCH_TARGET_DATE = _TODAY - timedelta(days=6)
+FAILED_REVIEW_TARGET_DATE = _TODAY - timedelta(days=7)
+MISSING_MAPPING_TARGET_DATE = _TODAY - timedelta(days=8)
+ORPHAN_TARGET_DATE = _TODAY - timedelta(days=9)
+MART_MISSING_TARGET_DATE = _TODAY - timedelta(days=10)
+COUNT_MISMATCH_TARGET_DATE = _TODAY - timedelta(days=11)
 
 
 @pytest.mark.requires_db


### PR DESCRIPTION
## Related Issue / 관련 이슈

Closes #104

## Summary / 요약

마트 테스트의 대상 날짜를 `date.today()` 기준 상대값으로 바꿔, 달력이 지나도 깨지지 않게 했다. 전체 스위트가 **503 passed / 0 failed** 로 복귀했다(직전 상시 상태: 500 passed / 3 failed).

## Why / 이유

테스트는 대상 날짜를 May-2026 **상수**로 박고, `GoldAggregator` 는 파티션 TTL 을 `date.today()` 기준 상대값으로 잰다(`src/gold/aggregator.py:278`). 두 값이 어긋나는 순간 적재 직후의 TTL 스윕(`src/gold/aggregator.py:128`, `:208`)이 **방금 쓴 파티션을 같은 실행 안에서 DROP** 한다. 그 결과 `srv_daily_review_list` 가 0행이 되고 `mart_freshness` 검증이 실패한다.

특정 커밋의 회귀가 아니라 달력이 지나며 터지는 선재 결함이다. PR #103 이전 커밋 `21537e3` 에서도 동일하게 재현된다.

이슈의 완료 조건대로 **TTL 로직은 건드리지 않았다**. 14일 보존은 의도된 운영 동작이고, 테스트에서 `retention_days` 를 넓히면 TTL DROP 경로 자체가 테스트에서 안 돌게 되므로 상대 날짜 쪽을 택했다.

## Changes / 변경 사항

- 대상 날짜 상수를 전부 `date.today()` 기준 상대값으로 전환. 파일마다 `_TODAY` 앵커를 한 번만 잡아 같은 파일의 날짜들이 동일한 "오늘" 을 공유하게 했다.
- 오프셋을 파일 간 전역 배분해 두 마트 테스트가 같은 날짜를 쓰지 않게 했다. 전부 보존 기간 14일 이내다.

  | 오프셋 | 파일 |
  |---|---|
  | 1 | `test_backend_datamart_serving_readiness.py` |
  | 2~3 | `test_backend_datamart_contract.py` |
  | 4~11 | `test_post_aggregate_validation.py` |
  | 12~13 | `test_pipeline_cli_validation.py` |

- 파티션 이름·파티션 범위·리뷰 타임스탬프를 리터럴 반복 대신 해당 날짜에서 파생하도록 바꿔, 월·연 경계에서도 어긋나지 않게 했다.
- 이슈 완료 조건의 "같은 패턴이 다른 마트 테스트에 더 있는지" 항목: `test_pipeline_cli_validation.py` 가 해당돼 함께 정리했다. `test_cleanse.py` 와 `test_batch_loader.py` 는 **제외**했다 — 두 파일의 May-2026 값은 target date 가 아니라 레코드 타임스탬프(`review_created_at`·`reviewed_at`)이고, `run_aggregate` 를 호출하지 않아 파티션을 만들지 않는다.

## Validation / 검증

- `PYTHONPATH=. TEST_POSTGRES_PORT=5433 uv run pytest -q` — **503 passed / 0 failed** (수정 전 500 passed / 3 failed)
- 미래 시각에서 마트 테스트 4개 파일 — 각 **19 passed**. 수집 이전에 시계를 고정하는 pytest 플러그인으로 실제 PostgreSQL 경로 그대로 실행했다.

  | 고정 시각 | 검증 대상 경계 | 결과 |
  |---|---|---|
  | 2027-03-05 | 월 경계 | 19 passed |
  | 2028-03-05 | 윤년 | 19 passed |
  | 2029-01-04 | 연 경계 | 19 passed |
  | 2030-12-31 | 연말 | 19 passed |

  통과 자체는 증거가 되지 않아서(원래도 현재 시각에서는 통과한다) 시계 고정이 실제로 적용됐는지 따로 확인했다: `date.today()` 가 `2029-01-04`, `CLI_FAILURE_TARGET_DATE` 가 `2028-12-22` 로 연 경계를 넘었고, 실제 CLI aggregate 가 만든 `srv_daily_review_list_2029_01_03` 파티션이 TTL 스윕에서 살아남아 DB 에 남았다 — 이게 정확히 고치려던 실패 모드다.
- `git diff --name-only -- src/ sql/` — 0건. 운영 코드·스키마 무변경.
- 시계 고정 실행이 만든 미래 날짜 파티션은 테스트 DB 에서 정리했다.

Not run:

- `Validate local DB bootstrap` (`.github/workflows/bootstrap-db.yml`) — PR 체크로 실행된다.

## Risk and Rollback / 위험 및 롤백

- Risk: 낮음. 테스트 전용 변경이고 운영 코드·스키마는 그대로다. 남은 제약은 오프셋 예산이다 — 마트 테스트 날짜는 보존 기간 14일 안에 들어와야 하는데 현재 1~13 을 다 쓰고 있다. 마트 테스트를 새로 추가하면서 날짜가 더 필요해지면 예산부터 다시 봐야 한다. 각 파일 상단 주석에 적어뒀다.
- Rollback: 커밋 revert. 되돌리면 이슈 #104 의 상시 실패 3건이 그대로 돌아온다.

## Review Focus / 리뷰 중점

- 오프셋 배분에 중복이 없는지, 그리고 13이 상한이라는 판단이 맞는지. 근거: TTL 은 `partition_date < date.today() - 14` 일 때만 DROP 하므로 오프셋 14까지 안전하지만, 실행이 자정을 넘길 때 cutoff 가 하루 밀리는 것까지 감안해 13을 상한으로 잡았다.
- `CONTRACT_PARTITION_NAME` 의 `contract_` 접두를 유지한 점. 이 이름은 TTL 정규식(`srv_daily_review_list_\d{4}_\d{2}_\d{2}`)에 걸리지 않아 자동 DROP 대상이 아니며, 정리는 `_cleanup_contract_probe` 가 맡는다. 기존 동작 그대로다.
