### PR TITLE
fix: CLI 기본 --steps를 실제로 돌아가는 파이프라인으로 교정 (#87)

### DIFF
--- a/scripts/cleanse_reviews.py
+++ b/scripts/cleanse_reviews.py
@@ -22,13 +22,9 @@ load_dotenv()
 from src.utils.minio_client import MinIOClient
 from src.utils.db_connector import DatabaseConnector
 from src.utils.logger import get_logger
-from src.processing.cleanse import ReviewCleaningPipeline
+from src.processing.cleanse import PROFANITY_PATH, SYNONYMS_PATH, ReviewCleaningPipeline
 
 logger = get_logger(__name__)
-
-_CONFIG_DIR = _PROJECT_ROOT / 'config' / 'dictionaries'
-SYNONYMS_PATH = str(_CONFIG_DIR / 'synonyms.json')
-PROFANITY_PATH = str(_CONFIG_DIR / 'profanity.json')
 
 
 def main():

--- a/src/pipeline/cli.py
+++ b/src/pipeline/cli.py
@@ -43,11 +43,16 @@ def build_arg_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run pipeline steps sequentially.")
     parser.add_argument(
         "--steps",
-        default="crawl,preprocess,features,action,embed",
+        # DAG(dags/financial_review_pipeline.py) 순서를 따른다. gold 는
+        # embedding/ABSA/action 을 오케스트레이션하므로 그 개별 단계를 겸한다.
+        # 날짜를 요구하는 단계(dept_assign, aggregate, post_aggregate_validate)는
+        # --target-date 없이는 의미가 없어 기본값에서 뺀다.
+        default="crawl,load,cleanse,gold",
         help=(
             "Comma-separated steps to run "
-            "(options: crawl, load, preprocess, features, action, embed, gold, "
-            "dept_assign, aggregate, post_aggregate_validate, validate)"
+            "(options: crawl, load, cleanse, features, action, embed, gold, "
+            "dept_assign, aggregate, post_aggregate_validate, validate; "
+            "preprocess is deprecated and always fails - use cleanse)"
         ),
     )
     parser.add_argument("--batch-size", type=int, default=100, help="Batch size for processing steps.")

--- a/src/pipeline/steps.py
+++ b/src/pipeline/steps.py
@@ -1,7 +1,7 @@
 """Pipeline step wrappers used by CLI and Airflow."""
 import warnings
 from dataclasses import asdict, dataclass
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from typing import Any, Callable
 
 from src.utils.logger import get_logger
@@ -55,6 +55,40 @@ def run_preprocess(batch_size: int = 100, limit: int | None = None, config_path:
     warnings.warn(msg, DeprecationWarning, stacklevel=2)
     logger.warning(msg)
     return RunResult(step="preprocess", status="failed", message=msg)
+
+
+def run_cleanse(target_date: str | None = None) -> RunResult:
+    """Run Bronze-to-Silver cleansing step (replaces the deprecated preprocess step).
+
+    scripts/cleanse_reviews.py 와 같은 경로를 탄다. 날짜를 생략하면 그 스크립트와
+    동일하게 어제를 처리한다 — 크롤이 전날치를 뒤늦게 적재하기 때문이다.
+    """
+    from src.processing.cleanse import (
+        PROFANITY_PATH,
+        SYNONYMS_PATH,
+        ReviewCleaningPipeline,
+    )
+    from src.utils.db_connector import DatabaseConnector
+    from src.utils.minio_client import MinIOClient
+
+    if target_date is not None:
+        try:
+            parsed_date = _parse_date_arg("target_date", target_date)
+        except ValueError as exc:
+            return RunResult(step="cleanse", status="failed", message=str(exc))
+    else:
+        parsed_date = date.today() - timedelta(days=1)
+
+    def _run():
+        pipeline = ReviewCleaningPipeline(
+            minio_client=MinIOClient(),
+            db_connector=DatabaseConnector(),
+            synonyms_path=SYNONYMS_PATH,
+            profanity_path=PROFANITY_PATH,
+        )
+        pipeline.run(target_date=parsed_date)
+
+    return _handle_step("cleanse", _run)
 
 
 def run_extract_features(batch_size: int = 100, limit: int | None = None, config_path: str | None = None) -> RunResult:
@@ -314,6 +348,7 @@ def run_steps(
     step_funcs: dict[str, Callable[[], RunResult]] = {
         "crawl": lambda: run_crawl(config_path),
         "load": lambda: run_load(batch_size=batch_size, config_path=config_path),
+        "cleanse": lambda: run_cleanse(target_date),
         "preprocess": lambda: run_preprocess(batch_size=batch_size, limit=limit, config_path=config_path),
         "features": lambda: run_extract_features(batch_size=batch_size, limit=limit, config_path=config_path),
         "action": lambda: run_action_analysis(batch_size=batch_size, limit=limit, config_path=config_path),

--- a/src/pipeline/steps.py
+++ b/src/pipeline/steps.py
@@ -57,7 +57,7 @@ def run_preprocess(batch_size: int = 100, limit: int | None = None, config_path:
     return RunResult(step="preprocess", status="failed", message=msg)
 
 
-def run_cleanse(target_date: str | None = None) -> RunResult:
+def run_cleanse(target_date: str | None = None, config_path: str | None = None) -> RunResult:
     """Run Bronze-to-Silver cleansing step (replaces the deprecated preprocess step).
 
     scripts/cleanse_reviews.py 와 같은 경로를 탄다. 날짜를 생략하면 그 스크립트와
@@ -82,7 +82,9 @@ def run_cleanse(target_date: str | None = None) -> RunResult:
     def _run():
         pipeline = ReviewCleaningPipeline(
             minio_client=MinIOClient(),
-            db_connector=DatabaseConnector(),
+            db_connector=(
+                DatabaseConnector(config_path) if config_path is not None else DatabaseConnector()
+            ),
             synonyms_path=SYNONYMS_PATH,
             profanity_path=PROFANITY_PATH,
         )
@@ -348,7 +350,7 @@ def run_steps(
     step_funcs: dict[str, Callable[[], RunResult]] = {
         "crawl": lambda: run_crawl(config_path),
         "load": lambda: run_load(batch_size=batch_size, config_path=config_path),
-        "cleanse": lambda: run_cleanse(target_date),
+        "cleanse": lambda: run_cleanse(target_date=target_date, config_path=config_path),
         "preprocess": lambda: run_preprocess(batch_size=batch_size, limit=limit, config_path=config_path),
         "features": lambda: run_extract_features(batch_size=batch_size, limit=limit, config_path=config_path),
         "action": lambda: run_action_analysis(batch_size=batch_size, limit=limit, config_path=config_path),

--- a/src/processing/cleanse.py
+++ b/src/processing/cleanse.py
@@ -6,6 +6,7 @@ Issue #14: Implement Review Data Cleansing Pipeline (Bronze to Silver)
 from collections import defaultdict
 from datetime import date as DateType
 import json
+from pathlib import Path
 import re
 import time
 from typing import Any, Dict, List
@@ -18,6 +19,13 @@ import pyarrow as pa
 
 from src.utils.logger import get_logger
 from src.utils.minio_client import MinIOClient
+
+
+# 정제 사전 경로. 정제기를 구동하는 쪽(scripts/cleanse_reviews.py, 파이프라인
+# cleanse 단계)이 각자 경로를 들고 있으면 한쪽만 옮겼을 때 조용히 갈라진다.
+_DICTIONARY_DIR = Path(__file__).resolve().parents[2] / 'config' / 'dictionaries'
+SYNONYMS_PATH = str(_DICTIONARY_DIR / 'synonyms.json')
+PROFANITY_PATH = str(_DICTIONARY_DIR / 'profanity.json')
 
 
 # =========================================================

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -1,4 +1,7 @@
+from datetime import date, timedelta
+import inspect
 from pathlib import Path
+import re
 import sys
 from unittest.mock import MagicMock, patch
 
@@ -8,8 +11,9 @@ ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from src.pipeline.cli import build_arg_parser  # noqa: E402
-from src.pipeline.steps import run_steps  # noqa: E402
+import src.pipeline.steps as steps_module  # noqa: E402
+from src.pipeline.cli import _parse_steps, build_arg_parser  # noqa: E402
+from src.pipeline.steps import RunResult, run_cleanse, run_steps  # noqa: E402
 
 
 def test_cli_parses_steps_and_batch_size():
@@ -61,3 +65,99 @@ def test_run_steps_passes_default_target_date_to_gold_and_aggregate(mock_run_gol
 
     assert mock_run_gold.call_args.kwargs["target_date"] is None
     assert mock_run_aggregate.call_args.kwargs["target_date"] is None
+
+
+# ========================================
+# 기본 --steps (#87)
+# ========================================
+
+
+def _registry_step_names() -> set[str]:
+    """run_steps 가 실제로 디스패치하는 단계 이름."""
+    src = inspect.getsource(steps_module.run_steps)
+    names = set(re.findall(r'^\s+"(\w+)": lambda', src, flags=re.MULTILINE))
+    # 정규식이 깨지면 빈 집합이 되어 아래 단언들이 조용히 통과한다. 앵커로 막는다.
+    assert {"crawl", "gold", "aggregate"} <= names, names
+    return names
+
+
+def _help_step_names(parser) -> list[str]:
+    """--steps help 문자열이 광고하는 단계 이름."""
+    help_text = {a.dest: a.help for a in parser._actions}["steps"]
+    listed = re.search(r"options: ([^;)]+)", help_text)
+    assert listed, help_text
+    return [name.strip() for name in listed.group(1).split(",")]
+
+
+def _stub_steps(monkeypatch, *, keep: frozenset[str]) -> None:
+    """keep 에 없는 run_* 을 성공 스텁으로 바꾼다. 실제 I/O 없이 디스패치만 본다."""
+    for name in dir(steps_module):
+        if not name.startswith("run_") or name in keep or name == "run_steps":
+            continue
+        monkeypatch.setattr(
+            steps_module,
+            name,
+            lambda *a, _n=name, **k: RunResult(step=_n, status="success"),
+        )
+
+
+def test_default_steps_run_to_completion(monkeypatch):
+    """인자 없이 실행하면 요청한 단계가 하나도 빠짐없이 실행된다.
+
+    run_preprocess 만 실물로 남긴다. deprecated 단계가 기본값에 돌아오면
+    run_steps 가 첫 실패에서 멈추므로 실행된 단계 목록이 짧아진다.
+    """
+    default_steps = _parse_steps(build_arg_parser().parse_args([]).steps)
+    _stub_steps(monkeypatch, keep=frozenset({"run_preprocess"}))
+
+    results = run_steps(default_steps)
+
+    # 스텁은 레지스트리 키가 아니라 함수명을 step 에 넣으므로 이름이 아니라
+    # "요청한 만큼 실행됐는가" 로 본다. 중단이 일어나면 목록이 짧아진다.
+    assert len(results) == len(default_steps), [r.as_dict() for r in results]
+    assert all(r.status == "success" for r in results), [r.as_dict() for r in results]
+
+
+def test_default_steps_exclude_deprecated_preprocess():
+    default_steps = _parse_steps(build_arg_parser().parse_args([]).steps)
+    assert "preprocess" not in default_steps
+
+
+def test_help_step_options_match_registry():
+    """help 가 광고하는 목록과 실제 디스패치 가능한 단계가 양방향으로 일치한다."""
+    parser = build_arg_parser()
+    advertised = _help_step_names(parser)
+    dispatchable = _registry_step_names()
+
+    assert not set(advertised) - dispatchable, "help 에만 있는 단계"
+    # preprocess 는 deprecated 라 목록 본문이 아니라 별도 문구로만 언급한다.
+    assert not dispatchable - set(advertised) - {"preprocess"}, "레지스트리에만 있는 단계"
+
+
+@patch("src.pipeline.steps.run_cleanse")
+def test_run_steps_passes_target_date_to_cleanse(mock_run_cleanse):
+    mock_run_cleanse.return_value = RunResult(step="cleanse", status="success")
+
+    run_steps(["cleanse"], target_date="2025-01-15")
+
+    assert mock_run_cleanse.call_args.args[0] == "2025-01-15"
+
+
+@patch("src.utils.minio_client.MinIOClient")
+@patch("src.utils.db_connector.DatabaseConnector")
+@patch("src.processing.cleanse.ReviewCleaningPipeline")
+def test_run_cleanse_defaults_to_yesterday(mock_pipeline, mock_db, mock_minio):
+    """날짜 생략 시 scripts/cleanse_reviews.py 와 같은 어제를 처리한다."""
+    result = run_cleanse()
+
+    assert result.status == "success", result.as_dict()
+    assert mock_pipeline.return_value.run.call_args.kwargs["target_date"] == (
+        date.today() - timedelta(days=1)
+    )
+
+
+def test_run_cleanse_rejects_invalid_target_date():
+    result = run_cleanse(target_date="today")
+
+    assert result.status == "failed"
+    assert "Expected YYYY-MM-DD" in result.message

--- a/tests/test_cli_parsing.py
+++ b/tests/test_cli_parsing.py
@@ -138,9 +138,10 @@ def test_help_step_options_match_registry():
 def test_run_steps_passes_target_date_to_cleanse(mock_run_cleanse):
     mock_run_cleanse.return_value = RunResult(step="cleanse", status="success")
 
-    run_steps(["cleanse"], target_date="2025-01-15")
+    run_steps(["cleanse"], target_date="2025-01-15", config_path="config/custom.yml")
 
-    assert mock_run_cleanse.call_args.args[0] == "2025-01-15"
+    assert mock_run_cleanse.call_args.kwargs["target_date"] == "2025-01-15"
+    assert mock_run_cleanse.call_args.kwargs["config_path"] == "config/custom.yml"
 
 
 @patch("src.utils.minio_client.MinIOClient")
@@ -154,6 +155,26 @@ def test_run_cleanse_defaults_to_yesterday(mock_pipeline, mock_db, mock_minio):
     assert mock_pipeline.return_value.run.call_args.kwargs["target_date"] == (
         date.today() - timedelta(days=1)
     )
+
+
+@patch("src.utils.minio_client.MinIOClient")
+@patch("src.utils.db_connector.DatabaseConnector")
+@patch("src.processing.cleanse.ReviewCleaningPipeline")
+def test_run_cleanse_forwards_config_path_to_db_connector(mock_pipeline, mock_db, mock_minio):
+    """--config 를 준 실행에서 cleanse 만 기본 설정 파일로 다른 DB 를 보면 안 된다."""
+    result = run_cleanse(target_date="2025-01-15", config_path="config/custom.yml")
+
+    assert result.status == "success", result.as_dict()
+    assert mock_db.call_args.args == ("config/custom.yml",)
+
+
+@patch("src.utils.minio_client.MinIOClient")
+@patch("src.utils.db_connector.DatabaseConnector")
+@patch("src.processing.cleanse.ReviewCleaningPipeline")
+def test_run_cleanse_without_config_path_uses_connector_default(mock_pipeline, mock_db, mock_minio):
+    run_cleanse(target_date="2025-01-15")
+
+    assert mock_db.call_args.args == ()
 
 
 def test_run_cleanse_rejects_invalid_target_date():


### PR DESCRIPTION
## Related Issue / 관련 이슈

Closes #87

## Summary / 요약

무인자 실행이 항상 실패하던 문제를 고쳤다. 기본값을 DAG 순서에 맞춘 `crawl,load,cleanse,gold` 로 바꾸고, 그 순서에 필요하지만 CLI 에 없던 `cleanse` 단계를 추가했다. 전체 스위트 **513 passed / 0 failed** (변경 전 505).

## Why / 이유

기본값이 `crawl,preprocess,features,action,embed` 인데 `run_preprocess` 는 Bronze→Silver 클렌징으로 대체되면서 **항상 실패하는 스텁**이 됐다(`src/pipeline/steps.py:49-57`). `run_steps()` 는 첫 실패에서 멈추므로(`src/pipeline/steps.py:284-285`) 무인자 실행은 `crawl` 직후 중단되고 exit 1 로 끝난다.

재현(이슈 절차 그대로):

```
{'step': 'preprocess', 'status': 'failed', 'message': 'run_preprocess is deprecated and has no effect. ...'}
executed: 1 / requested 4
```

## Changes / 변경 사항

### 1. 기본값 → `crawl,load,cleanse,gold`

`dags/financial_review_pipeline.py:147-153` 의 실행 순서를 따랐다.

- `gold` 는 embedding→ABSA→action 을 오케스트레이션하므로(`src/pipeline/steps.py:88`) 그 개별 단계를 겸한다. 구식 개별 호출을 유지할 이유가 없다.
- 날짜를 요구하는 단계(`dept_assign`, `aggregate`, `post_aggregate_validate`)는 `--target-date` 없이 의미가 없어 기본값에서 뺐다.

### 2. `cleanse` 단계 신설

이슈 AC 가 제시한 `crawl,load,cleanse,gold,aggregate` 를 그대로 쓸 수 없었다 — **`cleanse` 는 CLI 단계로 존재한 적이 없다.** 클렌징 경로는 `scripts/cleanse_reviews.py` 뿐이었다.

빼고 가면 중단은 사라지지만 대신 조용한 무동작이 된다. `gold` 는 `processing_status = CLEANED` 인 레코드만 집는데(`src/gold/orchestrator.py:120-126`) 그 상태를 만드는 게 `cleanse` 뿐이라, 없으면 gold 가 대상 0건으로 성공 처리된다. 그래서 `run_cleanse()` 를 추가했다. 스크립트와 같은 경로를 타고, 날짜 생략 시 동일하게 어제를 처리한다.

### 3. 사전 경로 상수 통합

`run_cleanse` 가 사전 경로를 새로 하드코딩하지 않도록 `SYNONYMS_PATH`·`PROFANITY_PATH` 를 소유자 모듈 `src/processing/cleanse.py` 로 올리고, 스크립트가 그것을 import 하게 했다. 스크립트 동작은 그대로다.

### 4. `--config` 전달 (`dfe3f40`, CodeRabbit 지적 반영)

`run_steps` 가 받은 `config_path` 를 cleanse 디스패치만 흘려버리고 있었다. `DatabaseConnector` 는 `config_path` 를 받고(`src/utils/db_connector.py:47`) `DATABASE_URL` 이 없을 때 그 파일로 접속 정보를 만들므로(`db_connector.py:51-52`), `--config` 를 준 실행에서 cleanse 만 다른 DB 에 `processing_status` 를 쓸 수 있었다. `MinIOClient` 은 config 경로를 받지 않아(env 전용) 전달 대상이 아니다.

### 5. help 문자열 정정

`preprocess` 를 평범한 선택지로 광고하고 있었다. `cleanse` 를 넣고 `preprocess` 는 deprecated 로 명시했다.

## Validation / 검증

### 가드가 실제로 잡는지 — 변이 6종 전수

`51 passed` 같은 숫자는 수정 전후가 같으면 아무것도 증명하지 않으므로(직전 PR #97 에서 겪음), 각 가드에 대해 **막으려는 결함을 재주입해** 실패하는지 확인했다.

| 변이 | 실패한 테스트 |
|---|---|
| 기본값을 원래대로(`preprocess` 재주입) | `test_default_steps_run_to_completion`, `test_default_steps_exclude_deprecated_preprocess` |
| 레지스트리에서 `cleanse` 제거 | 위 + `test_help_step_options_match_registry`, `test_run_steps_passes_target_date_to_cleanse` |
| `run_cleanse` 기본 날짜 어제→오늘 | `test_run_cleanse_defaults_to_yesterday` |
| `run_cleanse` 날짜 검증 제거 | `test_run_cleanse_rejects_invalid_target_date` |
| 레지스트리가 `target_date` 미전달 | `test_run_steps_passes_target_date_to_cleanse` |
| help 에 없는 단계를 레지스트리에 추가 | `test_help_step_options_match_registry` |
| 디스패치가 `config_path` 미전달 | `test_run_steps_passes_target_date_to_cleanse` |
| `run_cleanse` 가 `DatabaseConnector` 에 미전달 | `test_run_cleanse_forwards_config_path_to_db_connector` |
| `config_path` 가 `None` 일 때도 인자로 전달 | `test_run_cleanse_without_config_path_uses_connector_default` |

`test_default_steps_run_to_completion` 은 `run_preprocess` 만 실물로 남기고 나머지 `run_*` 을 성공 스텁으로 바꾼 뒤 기본값을 실행한다. deprecated 단계가 돌아오면 결과 목록이 짧아져 실패한다.

`_registry_step_names()` 는 정규식이 깨져 빈 집합이 되면 단언이 조용히 통과하므로 앵커 단언(`{"crawl","gold","aggregate"} <= names`)으로 막았다.

### 테스트

```
# AC 지정 명령
PYTHONPATH=. uv run pytest tests/test_cli_parsing.py tests/test_pipeline_cli_validation.py tests/test_pipeline_steps.py -q
38 passed

# 전체
PYTHONPATH=. TEST_POSTGRES_PORT=5433 uv run pytest -q
513 passed, 8 warnings
```

기본값 자체도 확인했다 — `crawl,load,cleanse,gold` 4개 전부 `run_steps` 레지스트리에 존재한다(미존재 0건).

### ruff

CI 게이트는 아니지만 신규 지적을 재봤다. 변경 4개 파일 기준 baseline 대비 신규는 `DTZ011 date.today()` **1건**이고, 같은 파일 `run_aggregate`(`src/pipeline/steps.py:286`)의 기존 용법과 동일하다. 파이프라인 날짜 의미가 로컬 기준이라 유지했다. 91자 줄에서 나온 `I001` 은 래핑으로 해소했다.

## Not changed / 건드리지 않은 것

- **`run_preprocess` 함수 자체는 남겼다.** 이슈가 범위 밖이라 명시했고, 레지스트리에도 그대로 둬 `--steps preprocess` 를 명시한 기존 호출은 동일하게 동작한다(deprecation 실패).
- DAG 는 무변경. `post_aggregate_validate` 만 CLI 를 쓰고 나머지는 스크립트나 `python -c` 직접 호출이라 이 변경의 영향을 받지 않는다.
- 문서 무변경. `scripts/run_pipeline.py` 를 언급하는 3곳(`docs/local-development.md:73`, `docs/backend-datamart-contract.md:322`, `docs/evidence/backend-datamart-serving-readiness/README.md:36`)이 **전부 `--steps` 를 명시**하고 있어 갱신할 기본값 서술이 없다. 이슈 본문의 "docs 가 안내하는 진입점의 기본 동작이 깨져 첫 실행부터 실패를 만난다" 는 이 점에서 과장이다 — 결함 자체는 실재하지만(항상 실패하는 기본값을 argparse 가 광고 중) 무인자 실행을 안내하는 문서는 없다.

## 관련

- #54 (CLOSED) — DAG 측 `preprocess` 제거. 본 PR 은 CLI 측 잔여분.
